### PR TITLE
Nircam loader

### DIFF
--- a/mosviz/loaders/mos_loaders.py
+++ b/mosviz/loaders/mos_loaders.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 from glue.config import data_factory
 from glue.core import Data
-from glue.core.coordinates import coordinates_from_header
+from glue.core.coordinates import coordinates_from_header, coordinates_from_wcs
 from astropy.io import fits
+from astropy.wcs import WCS
 import numpy as np
 
 """Data factories take a filename as input and return a Data object"""
@@ -54,5 +55,41 @@ def nirpsec_spectrum2D_reader(file_name):
     data.add_component(hdulist['DATA'].data, 'Spectral Flux')
     data.add_component(hdulist['VAR'].data, 'Variance')
     data.add_component(hdulist['QUALITY'].data, 'Data Quality')
+
+    return data
+
+@data_factory('NIRCam Image')
+def nircam_image_reader(file_name):
+    """
+    Data loader for simulated NIRCam image. This is for the
+    full image, where cut-outs will be created on the fly.
+
+    From the header:
+    If ISWFS is T, structure is:
+            Plane 1: Signal [frame3 - frame1] in ADU
+            Plane 2: Signal uncertainty [sqrt(2*RN/g + |frame3|)]
+    If ISWFS is F, structure is:
+            Plane 1: Signal from linear fit to ramp [ADU/sec]
+            Plane 2: Signal uncertainty [ADU/sec]
+    Note that in the later case, the uncertainty is simply the formal
+    uncertainty in the fit parameter (eg. uncorrelated, WRONG!). Noise
+    model to be implemented at a later date.
+    In the case of WFS, error is computed as
+      SQRT(2*sigma_read + |frame3|)
+    which should be a bit more correct - ~Fowler sampling.
+
+    The FITS file has a single extension with a data cube.
+    The data is the first slice of the cube and the uncertainty
+    is the second slice.
+    """
+
+    hdulist = fits.open(file_name)
+    data = Data(label='NIRCam Image')
+    wcs = WCS(hdulist[0].header)
+
+    # drop the last axis since the cube will be split
+    data.coords = coordinates_from_wcs(wcs.sub(2))
+    data.add_component(hdulist[0].data[0], 'Signal [ADU/s]')
+    data.add_component(hdulist[0].data[1], 'Error [ADU/s]')
 
     return data

--- a/mosviz/loaders/mos_loaders.py
+++ b/mosviz/loaders/mos_loaders.py
@@ -90,6 +90,6 @@ def nircam_image_reader(file_name):
     # drop the last axis since the cube will be split
     data.coords = coordinates_from_wcs(wcs.sub(2))
     data.add_component(hdulist[0].data[0], 'Signal [ADU/s]')
-    data.add_component(hdulist[0].data[1], 'Error [ADU/s]')
+    data.add_component(hdulist[0].data[1], 'Uncertainty [ADU/s]')
 
     return data


### PR DESCRIPTION
I added a loader for the NIRCam simulated image, should work just as well for a cutout or the full image as long as the data is stored in the FITS file the same way.