### PR TITLE
Added loaders for DEIMOS spectra and their ACS cutouts

### DIFF
--- a/mosviz/loaders/mos_loaders.py
+++ b/mosviz/loaders/mos_loaders.py
@@ -93,3 +93,59 @@ def nircam_image_reader(file_name):
     data.add_component(hdulist[0].data[1], 'Uncertainty [ADU/s]')
 
     return data
+
+@data_factory('DEIMOS 1D Spectrum')
+def deimos_spectrum1D_reader(file_name):
+    """
+    Data loader for Keck/DEIMOS 1D spectra.
+
+    This loads the 'Bxspf-B' (extension 1)
+    and 'Bxspf-R' (extension 2) and appends them
+    together to proudce the combined Red/Blue Spectrum
+    along with their Wavelength and Inverse Variance 
+    arrays.
+    """
+    
+    hdulist = fits.open(file_name)    
+    data = Data(label='1D Spectrum')
+
+    full_wl = np.append(hdulist[1].data['LAMBDA'][0], hdulist[2].data['LAMBDA'][0])
+    full_spec = np.append(hdulist[1].data['SPEC'][0], hdulist[2].data['SPEC'][0])
+    full_ivar = np.append(hdulist[1].data['IVAR'][0], hdulist[2].data['IVAR'][0])
+
+    data.add_component(full_wl, 'Wavelength')
+    data.add_component(full_spec, 'Spectral Flux')
+    data.add_component(full_ivar, 'Inverse Variance')
+
+    return data
+
+@data_factory('DEIMOS 2D Spectrum')
+def deimos_spectrum2D_reader(file_name):
+    """
+    Data loader for Keck/DEIMOS 2D spectra.
+
+    This loads only the Flux and Inverse variance. 
+    Wavelength information comes from the WCS.
+    """
+    
+    hdulist = fits.open(file_name)    
+    data = Data(label='2D Spectrum')
+    data.coords = coordinates_from_header(hdulist[1].header)
+    data.add_component(hdulist[1].data['FLUX'][0], 'Spectral Flux')
+    data.add_component(hdulist[1].data['IVAR'][0], 'Inverse Variance')
+    return data
+
+@data_factory('ACS Cutout Image')
+def acs_cutout_image_reader(file_name):
+    """
+    Data loader for the ACS cut-outs for the DEIMOS spectra.
+
+    The cutouts contain only the image.
+    """
+
+    hdulist = fits.open(file_name)
+    data = Data(label='ACS Cutout Image')
+    data.coords = coordinates_from_header(hdulist[0].header)
+    data.add_component(hdulist[0].data, 'Signal')
+
+    return data


### PR DESCRIPTION
Note: The 2D spectra are in separate files so the loader only loads either the red or blue, but the 1D spectra have the red and the blue in the same file so I concatenate them and give the full spectrum to the Data object.