### PR TITLE
Agnostic loader

### DIFF
--- a/mosviz/loaders/mos_loaders.py
+++ b/mosviz/loaders/mos_loaders.py
@@ -30,7 +30,6 @@ def nirspec_spectrum1d_reader(file_name):
 
     data = Data(label='1D Spectrum')
     data.header = hdulist['DATA'].header
-    data.coords = coordinates_from_header(hdulist[1].header)
     data.add_component(wavelength, 'Wavelength')
     data.add_component(hdulist['DATA'].data, 'Flux')
     data.add_component(hdulist['VAR'].data, 'Uncertainty')

--- a/mosviz/loaders/mos_loaders.py
+++ b/mosviz/loaders/mos_loaders.py
@@ -31,10 +31,9 @@ def nirspec_spectrum1d_reader(file_name):
     data = Data(label='1D Spectrum')
     data.header = hdulist['DATA'].header
     data.coords = coordinates_from_header(hdulist[1].header)
-    data.add_component(wavelength, 'Composed Wavelength')
-    data.add_component(hdulist['DATA'].data, 'Spectral Flux')
-    data.add_component(hdulist['VAR'].data, 'Variance')
-    data.add_component(hdulist['QUALITY'].data, 'Data Quality')
+    data.add_component(wavelength, 'Wavelength')
+    data.add_component(hdulist['DATA'].data, 'Flux')
+    data.add_component(hdulist['VAR'].data, 'Uncertainty')
 
     return data
 
@@ -55,9 +54,8 @@ def nirspec_spectrum2d_reader(file_name):
     data = Data(label='2D Spectrum')
     data.header = hdulist['DATA'].header
     data.coords = coordinates_from_header(hdulist[1].header)
-    data.add_component(hdulist['DATA'].data, 'Spectral Flux')
-    data.add_component(hdulist['VAR'].data, 'Variance')
-    data.add_component(hdulist['QUALITY'].data, 'Data Quality')
+    data.add_component(hdulist['DATA'].data, 'Flux')
+    data.add_component(hdulist['VAR'].data, 'Uncertainty')
 
     return data
 
@@ -94,8 +92,8 @@ def nircam_image_reader(file_name):
 
     # drop the last axis since the cube will be split
     data.coords = coordinates_from_wcs(wcs.sub(2))
-    data.add_component(hdulist[0].data[0], 'Signal [ADU/s]')
-    data.add_component(hdulist[0].data[1], 'Uncertainty [ADU/s]')
+    data.add_component(hdulist[0].data[0], 'Flux')
+    data.add_component(hdulist[0].data[1], 'Uncertainty')
 
     return data
 
@@ -121,8 +119,8 @@ def deimos_spectrum1D_reader(file_name):
     full_ivar = np.append(hdulist[1].data['IVAR'][0], hdulist[2].data['IVAR'][0])
 
     data.add_component(full_wl, 'Wavelength')
-    data.add_component(full_spec, 'Spectral Flux')
-    data.add_component(full_ivar, 'Inverse Variance')
+    data.add_component(full_spec, 'Flux')
+    data.add_component(full_ivar, 'Uncertainty')
 
     return data
 
@@ -138,14 +136,18 @@ def deimos_spectrum2D_reader(file_name):
     
     hdulist = fits.open(file_name)    
     data = Data(label='2D Spectrum')
-    data.coords = coordinates_from_header(hdulist[1].header)
+    hdulist[1].header['CTYPE2'] = 'Spatial Y'
+    wcs = WCS(hdulist[1].header)
+    # original WCS has both axes named "LAMBDA", glue requires unique component names
+
+    data.coords = coordinates_from_wcs(wcs)
     data.header = hdulist[1].header
-    data.add_component(hdulist[1].data['FLUX'][0], 'Spectral Flux')
-    data.add_component(hdulist[1].data['IVAR'][0], 'Inverse Variance')
+    data.add_component(hdulist[1].data['FLUX'][0], 'Flux')
+    data.add_component(hdulist[1].data['IVAR'][0], 'Uncertainty')
     return data
 
 
-@data_factory('ACS Cutout Image')
+@data_factory('Cutout Image')
 def acs_cutout_image_reader(file_name):
     """
     Data loader for the ACS cut-outs for the DEIMOS spectra.
@@ -157,6 +159,6 @@ def acs_cutout_image_reader(file_name):
     data = Data(label='ACS Cutout Image')
     data.coords = coordinates_from_header(hdulist[0].header)
     data.header = hdulist[0].header
-    data.add_component(hdulist[0].data, 'Signal')
+    data.add_component(hdulist[0].data, 'Flux')
 
     return data

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -414,7 +414,7 @@ class MOSVizViewer(DataViewer):
 
             self.image_widget.set_image(
                 image_data.get_component(
-                    image_data.id['Signal']).data, wcs=wcs,
+                    image_data.id['Flux']).data, wcs=wcs,
                 interpolation='none')
 
             self.image_widget.axes.set_xlabel("Spatial X")

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -10,7 +10,7 @@ from ..widgets.plots import Line1DWidget, ShareableAxesImageWidget, DrawableImag
 from ..loaders import mos_loaders
 from ..widgets.viewer_options import OptionsWidget
 
-from glue import config
+import config
 from glue.core import message as msg
 from glue.core import Subset
 from glue.core.exceptions import IncompatibleAttribute
@@ -317,37 +317,18 @@ class MOSVizViewer(DataViewer):
         if "loaders" in self.catalog.meta:
             # if loader is specified
             if "spec1d" in self.catalog.meta["loaders"]:
-                # check .glue/config.py for custom loaders
-                if hasattr(config, self.catalog.meta["loaders"]["spec1d"]):
-                    spectrum1d_loader = getattr(config, self.catalog.meta["loaders"]["spec1d"])
-
-                # check built-in loaders
-                else:
-                    spectrum1d_loader = getattr(mos_loaders, self.catalog.meta["loaders"]["spec1d"])
-
-            # Use the NIRSpec loader by default.
-            else:
-                spectrum1d_loader = mos_loaders.nirspec_spectrum1d_reader
-
+                spectrum1d_loader = next((x.function for x in config.data_factory.members if x.label ==  self.catalog.meta["loaders"]["spec1d"]),
+                     next(x.function for x in config.data_factory.members if x.label == "NIRSpec 1D Spectrum"))
 
             if "spec2d" in self.catalog.meta["loaders"]:
-                if hasattr(config, self.catalog.meta["loaders"]["spec2d"]):
-                    spectrum2d_loader = getattr(config, self.catalog.meta["loaders"]["spec2d"])
-                else:
-                    spectrum2d_loader = getattr(mos_loaders, self.catalog.meta["loaders"]["spec2d"])
-            else:
-                spectrum2d_loader = mos_loaders.nirspec_spectrum2d_reader
+                spectrum2d_loader = next((x.function for x in config.data_factory.members if x.label ==  self.catalog.meta["loaders"]["spec2d"]),
+                     next(x.function for x in config.data_factory.members if x.label == "NIRSpec 2D Spectrum"))
 
             if "image" in self.catalog.meta["loaders"]:
-                if hasattr(config, self.catalog.meta["loaders"]["image"]):
-                    cutout_loader = getattr(config, self.catalog.meta["loaders"]["image"])
-                else:
-                    cutout_loader = getattr(mos_loaders, self.catalog.meta["loaders"]["image"])
-
-            # Use the ACS cutout loader by default.
-            else:
-                cutout_loader = mos_loaders.acs_cutout_image_reader
+                cutout_loader = next((x.function for x in config.data_factory.members if x.label ==  self.catalog.meta["loaders"]["image"]),
+                     next(x.function for x in config.data_factory.members if x.label == "Cutout Image"))
         else:
+            # Use NIRSpec loaders by default.
             spectrum1d_loader = mos_loaders.nirspec_spectrum1d_reader
             spectrum2d_loader = mos_loaders.nirspec_spectrum2d_reader
             cutout_loader = mos_loaders.acs_cutout_image_reader

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -390,8 +390,8 @@ class MOSVizViewer(DataViewer):
         if spec1d_data is not None:
             self.spectrum1d_widget.set_data(
                 x=spec1d_data.get_component(spec1d_data.id['Wavelength']).data,
-                y=spec1d_data.get_component(spec1d_data.id['Spectral Flux']).data,
-                yerr=spec1d_data.get_component(spec1d_data.id['Variance']).data)
+                y=spec1d_data.get_component(spec1d_data.id['Flux']).data,
+                yerr=spec1d_data.get_component(spec1d_data.id['Uncertainty']).data)
 
             self.spectrum1d_widget.axes.set_xlabel("Wavelength")
             self.spectrum1d_widget.axes.set_ylabel("Flux")
@@ -401,7 +401,7 @@ class MOSVizViewer(DataViewer):
 
             self.spectrum2d_widget.set_image(
                 image=spec2d_data.get_component(
-                    spec2d_data.id['Spectral Flux']).data,
+                    spec2d_data.id['Flux']).data,
                 wcs=wcs, interpolation='none', aspect='auto')
 
             self.spectrum2d_widget.axes.set_xlabel("Wavelength")

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -7,9 +7,10 @@ from qtpy.uic import loadUi
 
 from ..widgets.toolbars import MOSViewerToolbar
 from ..widgets.plots import Line1DWidget, ShareableAxesImageWidget, DrawableImageWidget
-from ..loaders.mos_loaders import *
+from ..loaders import mos_loaders
 from ..widgets.viewer_options import OptionsWidget
 
+from glue import config
 from glue.core import message as msg
 from glue.core import Subset
 from glue.core.exceptions import IncompatibleAttribute
@@ -238,9 +239,9 @@ class MOSVizViewer(DataViewer):
 
         # Clear the table
         self.catalog = Table()
+        self.catalog.meta = data.meta
 
         col_names = data.components
-
         for att in col_names:
             cid = data.id[att]
             component = data.get_component(cid)
@@ -312,9 +313,49 @@ class MOSVizViewer(DataViewer):
             A `row` object representing a row in the MOS catalog. Each key
             should be a column name.
         """
-        spec1d_data = nirspec_spectrum1d_reader(row['spectrum1d'])
-        spec2d_data = nirspec_spectrum2d_reader(row['spectrum2d'])
-        image_data = acs_cutout_image_reader(row['cutout'])
+
+        if "loaders" in self.catalog.meta:
+            # if loader is specified
+            if "spec1d" in self.catalog.meta["loaders"]:
+                # check .glue/config.py for custom loaders
+                if hasattr(config, self.catalog.meta["loaders"]["spec1d"]):
+                    spectrum1d_loader = getattr(config, self.catalog.meta["loaders"]["spec1d"])
+
+                # check built-in loaders
+                else:
+                    spectrum1d_loader = getattr(mos_loaders, self.catalog.meta["loaders"]["spec1d"])
+
+            # Use the NIRSpec loader by default.
+            else:
+                spectrum1d_loader = mos_loaders.nirspec_spectrum1d_reader
+
+
+            if "spec2d" in self.catalog.meta["loaders"]:
+                if hasattr(config, self.catalog.meta["loaders"]["spec2d"]):
+                    spectrum2d_loader = getattr(config, self.catalog.meta["loaders"]["spec2d"])
+                else:
+                    spectrum2d_loader = getattr(mos_loaders, self.catalog.meta["loaders"]["spec2d"])
+            else:
+                spectrum2d_loader = mos_loaders.nirspec_spectrum2d_reader
+
+            if "image" in self.catalog.meta["loaders"]:
+                if hasattr(config, self.catalog.meta["loaders"]["image"]):
+                    cutout_loader = getattr(config, self.catalog.meta["loaders"]["image"])
+                else:
+                    cutout_loader = getattr(mos_loaders, self.catalog.meta["loaders"]["image"])
+
+            # Use the ACS cutout loader by default.
+            else:
+                cutout_loader = mos_loaders.acs_cutout_image_reader
+        else:
+            spectrum1d_loader = mos_loaders.nirspec_spectrum1d_reader
+            spectrum2d_loader = mos_loaders.nirspec_spectrum2d_reader
+            cutout_loader = mos_loaders.acs_cutout_image_reader
+
+        spec1d_data = spectrum1d_loader(row['spectrum1d'])
+        spec2d_data = spectrum2d_loader(row['spectrum2d'])
+        image_data = cutout_loader(row['cutout'])
+
 
         self._update_data_components(spec1d_data)
         self._update_data_components(spec2d_data)

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -10,7 +10,7 @@ from ..widgets.plots import Line1DWidget, ShareableAxesImageWidget, DrawableImag
 from ..loaders import mos_loaders
 from ..widgets.viewer_options import OptionsWidget
 
-import config
+from glue import config
 from glue.core import message as msg
 from glue.core import Subset
 from glue.core.exceptions import IncompatibleAttribute


### PR DESCRIPTION
With the newest glue, Data has a .meta attribute so we can get the loader names from the catalog header.  I've set it so that MOSViz checks for the loaders first in .glue/config.py then in mosviz/loaders/mos_loaders.py and if it can't find the loader (or one isn't specified) it tries to use JWST loaders.