### PR TITLE
Refactor slit-plotting code

### DIFF
--- a/docs/readingindata.rst
+++ b/docs/readingindata.rst
@@ -46,7 +46,6 @@ Right ascension of the slit center (FK5 J2000)                 ``ra``           
 Declination of the slit center (FK5 J2000)                     ``dec``          degrees
 Width of the slit                                              ``slit_width``   arcseconds
 Length of the slit                                             ``slit_length``  arcseconds
-Position angle of the slit (counter-clockwise from North)      ``slit_angle``   degrees
 ============================================================== =============== =============
 
 The columns can have any name, but if they are given the name in the **Default
@@ -586,7 +585,6 @@ expected names:
     # - {name: cutout, datatype: string}
     # - {name: slit_width, unit: arcsec, datatype: float64}
     # - {name: slit_length, unit: arcsec, datatype: float64}
-    # - {name: slit_angle, unit: degree, datatype: float64}
     # - {name: pix_scale, datatype: float64}
     id ra dec spectrum2d spectrum1d cutout slit_width slit_length pix_scale
     deimos_12004808 214.21968 52.410386 Spectra/slit.1153.151R.fits.gz Spectra/spec1d.1153.151.12004808.fits Cutouts/12004808.acs.v_6ac_.fits 0.2 3.3 0.0 0.66

--- a/mosviz/loaders/loader_selection.py
+++ b/mosviz/loaders/loader_selection.py
@@ -32,8 +32,6 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
                {'property': 'slit_width', 'default': 'slit_width',
                 'categorical': False, 'numeric': True},
                {'property': 'slit_length', 'default': 'slit_length',
-                'categorical': False, 'numeric': True},
-               {'property': 'slit_angle', 'default': 'slit_angle',
                 'categorical': False, 'numeric': True}]
 
     loader_spectrum1d = CallbackProperty()
@@ -48,7 +46,6 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
     slit_dec = CallbackProperty()
     slit_width = CallbackProperty()
     slit_length = CallbackProperty()
-    slit_angle = CallbackProperty()
 
     slit_north_aligned = CallbackProperty()
 
@@ -131,12 +128,6 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
 
         self.data = data
 
-        self.add_callback('slit_north_aligned', self._toggle_slit_angle_combo)
-        self._toggle_slit_angle_combo()
-
-    def _toggle_slit_angle_combo(self, *args):
-        self.ui.combotext_slit_angle.setEnabled(not self.slit_north_aligned)
-
     def accept(self):
 
         if 'loaders' not in self.data.meta:
@@ -150,8 +141,6 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
             self.data.meta['special_columns'] = {}
 
         for column in self.columns:
-            if self.slit_north_aligned and column == 'slit_north_aligned':
-                continue
             self.data.meta['special_columns'][column['property']] = getattr(self, column['property'])
 
         self.data.meta['loaders_confirmed'] = True
@@ -181,7 +170,6 @@ if __name__ == "__main__":
     d['dec'] = [1, 2, 2]
     d['slit_width'] = [1, 2, 2]
     d['slit_length'] = [1, 2, 2]
-    d['slit_angle'] = [1, 2, 2]
 
     print(confirm_loaders_and_column_names(d))
     print(confirm_loaders_and_column_names(d))

--- a/mosviz/loaders/loader_selection.py
+++ b/mosviz/loaders/loader_selection.py
@@ -50,6 +50,8 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
     slit_length = CallbackProperty()
     slit_angle = CallbackProperty()
 
+    slit_north_aligned = CallbackProperty()
+
     def __init__(self, parent=None, data=None):
 
         QtWidgets.QDialog.__init__(self, parent=parent)
@@ -129,6 +131,12 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
 
         self.data = data
 
+        self.add_callback('slit_north_aligned', self._toggle_slit_angle_combo)
+        self._toggle_slit_angle_combo()
+
+    def _toggle_slit_angle_combo(self, *args):
+        self.ui.combotext_slit_angle.setEnabled(not self.slit_north_aligned)
+
     def accept(self):
 
         if 'loaders' not in self.data.meta:
@@ -142,6 +150,8 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
             self.data.meta['special_columns'] = {}
 
         for column in self.columns:
+            if self.slit_north_aligned and column == 'slit_north_aligned':
+                continue
             self.data.meta['special_columns'][column['property']] = getattr(self, column['property'])
 
         self.data.meta['loaders_confirmed'] = True

--- a/mosviz/loaders/loader_selection.ui
+++ b/mosviz/loaders/loader_selection.ui
@@ -216,6 +216,13 @@
      <item row="9" column="1">
       <widget class="QComboBox" name="combotext_slit_ra"/>
      </item>
+     <item row="13" column="2">
+      <widget class="QCheckBox" name="bool_slit_north_aligned">
+       <property name="text">
+        <string>North-aligned</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/mosviz/loaders/loader_selection.ui
+++ b/mosviz/loaders/loader_selection.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>554</height>
+    <width>452</width>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,22 +16,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Column</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0" colspan="3">
       <widget class="QLabel" name="label">
        <property name="sizePolicy">
@@ -57,43 +41,8 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
-      <widget class="QComboBox" name="combotext_slit_width"/>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Right Ascension</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="combotext_loader_spectrum1d"/>
-     </item>
-     <item row="5" column="2">
-      <widget class="QComboBox" name="combotext_loader_cutout"/>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Image Cutouts</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="combotext_spectrum1d"/>
-     </item>
-     <item row="13" column="1">
-      <widget class="QComboBox" name="combotext_slit_angle"/>
-     </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="Line" name="line">
+     <item row="7" column="0" colspan="3">
+      <widget class="Line" name="line_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -118,31 +67,18 @@
      <item row="12" column="1">
       <widget class="QComboBox" name="combotext_slit_length"/>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_3">
+     <item row="5" column="2">
+      <widget class="QComboBox" name="combotext_loader_cutout"/>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_9">
        <property name="text">
-        <string>2D Spectra</string>
+        <string>Declination</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QComboBox" name="combotext_spectrum2d"/>
-     </item>
-     <item row="7" column="0" colspan="3">
-      <widget class="Line" name="line_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="combotext_cutout"/>
-     </item>
-     <item row="4" column="2">
-      <widget class="QComboBox" name="combotext_loader_spectrum2d"/>
      </item>
      <item row="8" column="1">
       <widget class="QLabel" name="label_7">
@@ -160,10 +96,71 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_9">
+     <item row="1" column="0" colspan="3">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QComboBox" name="combotext_loader_spectrum2d"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Declination</string>
+        <string>2D Spectra</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Right Ascension</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="combotext_spectrum2d"/>
+     </item>
+     <item row="9" column="1">
+      <widget class="QComboBox" name="combotext_slit_ra"/>
+     </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="combotext_cutout"/>
+     </item>
+     <item row="11" column="1">
+      <widget class="QComboBox" name="combotext_slit_width"/>
+     </item>
+     <item row="3" column="2">
+      <widget class="QComboBox" name="combotext_loader_spectrum1d"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_5">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Column</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Image Cutouts</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -180,8 +177,8 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
-      <widget class="QComboBox" name="combotext_slit_dec"/>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="combotext_spectrum1d"/>
      </item>
      <item row="11" column="0">
       <widget class="QLabel" name="label_10">
@@ -193,15 +190,8 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="label_12">
-       <property name="text">
-        <string>Position Angle</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
+     <item row="10" column="1">
+      <widget class="QComboBox" name="combotext_slit_dec"/>
      </item>
      <item row="12" column="0">
       <widget class="QLabel" name="label_11">
@@ -213,13 +203,13 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
-      <widget class="QComboBox" name="combotext_slit_ra"/>
-     </item>
-     <item row="13" column="2">
-      <widget class="QCheckBox" name="bool_slit_north_aligned">
+     <item row="13" column="0" colspan="3">
+      <widget class="QLabel" name="label_12">
        <property name="text">
-        <string>North-aligned</string>
+        <string>Note that the slit is assumed to be aligned with the y-axis of the cutouts</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -453,7 +453,7 @@ class MOSVizViewer(DataViewer):
             slit_width = row[self.catalog.meta["special_columns"]["slit_width"]]
             slit_length = row[self.catalog.meta["special_columns"]["slit_length"]]
 
-            skycoord = SkyCoord(ra, dec)
+            skycoord = SkyCoord(ra, dec, frame='fk5')
             xp, yp = skycoord.to_pixel(wcs)
 
             scale = np.sqrt(proj_plane_pixel_area(wcs)) * 3600.

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -138,6 +138,7 @@ class DrawableImageWidget(MOSImageWidget):
         super(DrawableImageWidget, self).__init__(*args, **kwargs)
         self._slit_patch = None
 
-    def draw_shapes(self, x=0, y=0, width=100, length=100):
-        self._slit_patch = plt.Rectangle((x-length, y-width), width, length, fc='r')
-        # self.axes.add_patch(self._slit_patch)
+    def draw_region(self, region):
+        if self._slit_patch is not None:
+            self._slit_patch.remove()
+        self._slit_patch = self._axes.add_patch(region.as_patch(edgecolor='red', facecolor='none'))

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -16,6 +16,7 @@ import numpy as np
 from astropy.wcs import WCS, WCSSUB_SPECTRAL
 
 from matplotlib import rcParams
+from matplotlib.patches import Rectangle
 # rcParams.update({'figure.autolayout': True})
 
 __all__ = ['Line1DWidget', 'ShareableAxesImageWidget',
@@ -138,7 +139,10 @@ class DrawableImageWidget(MOSImageWidget):
         super(DrawableImageWidget, self).__init__(*args, **kwargs)
         self._slit_patch = None
 
-    def draw_region(self, region):
+    def draw_rectangle(self, x=None, y=None, width=None, height=None):
         if self._slit_patch is not None:
             self._slit_patch.remove()
-        self._slit_patch = self._axes.add_patch(region.as_patch(edgecolor='red', facecolor='none'))
+        self._slit_patch = Rectangle((x - width / 2, y - height / 2),
+                                     width=width, height=height,
+                                     edgecolor='red', facecolor='none')
+        self._axes.add_patch(self._slit_patch)


### PR DESCRIPTION
The slit is back:

<img width="990" alt="screen shot 2017-05-30 at 21 55 21" src="https://cloud.githubusercontent.com/assets/314716/26604597/b83b9804-4582-11e7-87ea-c825038a7c9e.png">

Note that I am assuming the ``ra`` and ``dec`` columns in the table give the origin of the slit (not of the source). If this is not an assumption we want to make, we should require ``slit_ra`` and ``slit_dec`` to be specified in the table (since we don't care about the actual source position).

We're also assuming for now that the RA/Dec are given in FK5/J2000

I've also removed the variable slit angle that I had added in the previous pull request, which simplifies things in terms of plotting.