### PR TITLE
Fix locking of axes

### DIFF
--- a/mosviz/compat.py
+++ b/mosviz/compat.py
@@ -1,5 +1,7 @@
 # Code to provide backward-compatibility with old versions of glue
 
+from __future__ import absolute_import, division, print_function
+
 from glue.core.qt.data_combo_helper import ComponentIDComboHelper as OriginalComponentIDComboHelper
 from glue.core.hub import HubListener
 

--- a/mosviz/loaders/loader_selection.py
+++ b/mosviz/loaders/loader_selection.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import os
 from itertools import repeat
 

--- a/mosviz/loaders/mos_loaders.py
+++ b/mosviz/loaders/mos_loaders.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+import numpy as np
+
+from astropy.io import fits
+from astropy.wcs import WCS
+
 from glue.config import data_factory
 from glue.core import Data
 from glue.core.coordinates import coordinates_from_header, coordinates_from_wcs
-from astropy.io import fits
-from astropy.wcs import WCS
-import numpy as np
 
 __all__ = ['nirspec_spectrum1d_reader',
            'nirspec_spectrum2d_reader',
@@ -20,26 +22,35 @@ CUTOUT_LOADERS = {}
 
 
 def mosviz_spectrum1d_loader(label, *args, **kwargs):
+
     adder = data_factory(label, *args, **kwargs)
+
     def wrapper(func):
         SPECTRUM1D_LOADERS[label] = func
         return adder(func)
+
     return wrapper
 
 
 def mosviz_spectrum2d_loader(label, *args, **kwargs):
+
     adder = data_factory(label, *args, **kwargs)
+
     def wrapper(func):
         SPECTRUM2D_LOADERS[label] = func
         return adder(func)
+
     return wrapper
 
 
 def mosviz_cutout_loader(label, *args, **kwargs):
+
     adder = data_factory(label, *args, **kwargs)
+
     def wrapper(func):
         CUTOUT_LOADERS[label] = func
         return adder(func)
+
     return wrapper
 
 

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -75,6 +75,11 @@ class MOSVizViewer(DataViewer):
         self.spectrum2d_image_share = SharedAxisHelper(self.spectrum2d_widget._axes,
                                                        self.image_widget._axes)
 
+        # We only need to set the image widget to keep the same aspect ratio
+        # since the two other viewers don't require square pixels, so the axes
+        # should not change shape.
+        self.image_widget._axes.set_adjustable('datalim')
+
         self.meta_form_layout = self.central_widget.meta_form_layout
 
         self.central_widget.left_vertical_splitter.insertWidget(0, self.image_widget)

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -1,16 +1,11 @@
+from __future__ import print_function, division, absolute_import
+
 import os
 
 import numpy as np
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget, QLineEdit
 from qtpy.uic import loadUi
-
-from ..widgets.toolbars import MOSViewerToolbar
-from ..widgets.plots import Line1DWidget, MOSImageWidget, DrawableImageWidget
-from ..loaders.loader_selection import confirm_loaders_and_column_names
-from ..loaders.mos_loaders import SPECTRUM1D_LOADERS, SPECTRUM2D_LOADERS, CUTOUT_LOADERS
-from ..widgets.viewer_options import OptionsWidget
-from ..widgets.share_axis import SharedAxisHelper
 
 from glue.core import message as msg
 from glue.core import Subset
@@ -27,11 +22,17 @@ from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
 from astropy.wcs.utils import proj_plane_pixel_area
 
-
 try:
     from specviz.external.glue.data_viewer import SpecVizViewer
 except ImportError:
     SpecVizViewer = None
+
+from ..widgets.toolbars import MOSViewerToolbar
+from ..widgets.plots import Line1DWidget, MOSImageWidget, DrawableImageWidget
+from ..loaders.loader_selection import confirm_loaders_and_column_names
+from ..loaders.mos_loaders import SPECTRUM1D_LOADERS, SPECTRUM2D_LOADERS, CUTOUT_LOADERS
+from ..widgets.viewer_options import OptionsWidget
+from ..widgets.share_axis import SharedAxisHelper
 
 __all__ = ['MOSVizViewer']
 
@@ -500,7 +501,6 @@ class MOSVizViewer(DataViewer):
 
             self.spectrum2d_widget._redraw()
 
-
         # Clear the meta information widget
         # NOTE: this process is inefficient
         for i in range(self.meta_form_layout.count()):
@@ -527,8 +527,6 @@ class MOSVizViewer(DataViewer):
         # Here we only change the setting if x or y are not None
         # since if set_locked_axes is called with eg. x=True, then
         # we shouldn't change the y setting.
-
-        print('x, y', x, y)
 
         if x is not None:
             self.spectrum2d_spectrum1d_share.sharex = x

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -79,32 +79,27 @@ class MOSImageWidget(StandaloneImageWidget):
 
     def __init__(self, *args, **kwargs):
         super(MOSImageWidget, self).__init__(*args, **kwargs)
+        self._axes.set_adjustable('datalim')
 
     def set_status(self, status):
         pass
 
+
 class ShareableAxesImageWidget(MOSImageWidget):
-    def __init__(self, *args, **kwargs):
-        super(ShareableAxesImageWidget, self).__init__(*args, **kwargs)
 
     def set_locked_axes(self, sharex=None, sharey=None):
+
+        # Note that Matplotlib does not have a public API for making axes
+        # shareable after instantiation, so we need to access private attributes
+        # here. This is not ideal,
+
         if sharex is not None and sharex is not False:
             self.axes._shared_x_axes.join(self.axes, sharex)
-            if sharex._adjustable == 'box':
-                sharex._adjustable = 'datalim'
-                #warnings.warn(
-                #    'shared axes: "adjustable" is being changed to "datalim"')
-            self._adjustable = 'datalim'
         elif self._axes._sharex is not None and sharex is False:
             self.axes._shared_x_axes.remove(self._axes._sharex)
 
         if sharey is not None and sharey is not False:
             self.axes._shared_y_axes.join(self.axes, sharey)
-            if sharey._adjustable == 'box':
-                sharey._adjustable = 'datalim'
-                #warnings.warn(
-                #    'shared axes: "adjustable" is being changed to "datalim"')
-            self._adjustable = 'datalim'
         elif self._axes._sharey is not None and sharey is False:
             self.axes._shared_y_axes.remove(self._axes._sharey)
 

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -19,8 +19,7 @@ from matplotlib import rcParams
 from matplotlib.patches import Rectangle
 # rcParams.update({'figure.autolayout': True})
 
-__all__ = ['Line1DWidget', 'ShareableAxesImageWidget',
-           'DrawableImageWidget', 'MOSImageWidget']
+__all__ = ['Line1DWidget', 'DrawableImageWidget', 'MOSImageWidget']
 
 
 class Line1DWidget(QMainWindow):
@@ -46,18 +45,15 @@ class Line1DWidget(QMainWindow):
         self.addToolBar(self.toolbar)
         self.setCentralWidget(self.central_widget)
 
-        self._axes = None
+        self._axes = self.figure.add_subplot(111)
 
     @property
     def axes(self):
         return self._axes
 
     def set_data(self, x, y, yerr=None):
-        # Create an axis
-        self._axes = self.figure.add_subplot(111)
 
-        # Discards the old graph
-        self._axes.hold(False)
+        self._axes.cla()
 
         # Plot data
         if yerr is None:
@@ -83,28 +79,6 @@ class MOSImageWidget(StandaloneImageWidget):
 
     def set_status(self, status):
         pass
-
-
-class ShareableAxesImageWidget(MOSImageWidget):
-
-    def set_locked_axes(self, sharex=None, sharey=None):
-
-        # Note that Matplotlib does not have a public API for making axes
-        # shareable after instantiation, so we need to access private attributes
-        # here. This is not ideal,
-
-        if sharex is not None and sharex is not False:
-            self.axes._shared_x_axes.join(self.axes, sharex)
-        elif self._axes._sharex is not None and sharex is False:
-            self.axes._shared_x_axes.remove(self._axes._sharex)
-
-        if sharey is not None and sharey is not False:
-            self.axes._shared_y_axes.join(self.axes, sharey)
-        elif self._axes._sharey is not None and sharey is False:
-            self.axes._shared_y_axes.remove(self._axes._sharey)
-
-        self._axes._sharex = sharex
-        self._axes._sharey = sharey
 
 
 class DrawableImageWidget(MOSImageWidget):

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -1,23 +1,19 @@
-from qtpy.QtWidgets import QMainWindow, QWidget
+from __future__ import print_function, division, absolute_import
+
+from qtpy.QtWidgets import QMainWindow
 from qtpy.QtCore import Signal
 
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.patches import Rectangle
 
 from glue.viewers.image.qt.viewer_widget import StandaloneImageWidget
-from glue.viewers.common.qt.toolbar import BasicToolbar
+
 try:
     from glue.viewers.common.qt.mpl_toolbar import MatplotlibViewerToolbar
 except ImportError:
     from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
 
-import numpy as np
-from astropy.wcs import WCS, WCSSUB_SPECTRAL
-
-from matplotlib import rcParams
-from matplotlib.patches import Rectangle
-# rcParams.update({'figure.autolayout': True})
 
 __all__ = ['Line1DWidget', 'DrawableImageWidget', 'MOSImageWidget']
 

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -80,27 +80,6 @@ class MOSImageWidget(StandaloneImageWidget):
     def __init__(self, *args, **kwargs):
         super(MOSImageWidget, self).__init__(*args, **kwargs)
 
-    def set_image(self, image=None, wcs=None, header=None, **kwargs):
-        super(MOSImageWidget, self).set_image(image, wcs, **kwargs)
-
-        if header is not None:
-            hwcs = WCS(header)
-
-            # Try to reference the spectral axis
-            hwcs_spec = hwcs.sub([WCSSUB_SPECTRAL])
-
-            # Check to see if it actually is a real coordinate description
-            if hwcs_spec.naxis == 0:
-                # It's not real, so attempt to get the spectral axis by
-                # specifying axis by integer
-                hwcs_spec = hwcs.sub([hwcs.naxis])
-
-            # Construct the dispersion array
-            dispersion = hwcs_spec.all_pix2world(
-                np.arange(image.shape[0]), 0)[0]
-
-            self.axes.set_xticklabels(["{}".format(x) for x in dispersion])
-
     def set_status(self, status):
         pass
 

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -42,6 +42,7 @@ class Line1DWidget(QMainWindow):
         self.setCentralWidget(self.central_widget)
 
         self._axes = self.figure.add_subplot(111)
+        self._artists = []
 
     @property
     def axes(self):
@@ -49,13 +50,19 @@ class Line1DWidget(QMainWindow):
 
     def set_data(self, x, y, yerr=None):
 
-        self._axes.cla()
+        # Note: we can't use self._axes.cla() here since that removes events
+        # which will cause the locked axes to not work.
+        for artist in self._artists:
+            try:
+                artist.remove()
+            except ValueError:  # some artists may already not be in plot
+                pass
 
         # Plot data
         if yerr is None:
-            self._axes.plot(x, y)
+            self._artists = self._axes.plot(x, y, color='k')
         else:
-            self._axes.errorbar(x, y, yerr=yerr)
+            self._artists = [self._axes.errorbar(x, y, yerr=yerr, color='k')]
 
         # Refresh canvas
         self._redraw()
@@ -71,7 +78,6 @@ class MOSImageWidget(StandaloneImageWidget):
 
     def __init__(self, *args, **kwargs):
         super(MOSImageWidget, self).__init__(*args, **kwargs)
-        self._axes.set_adjustable('datalim')
 
     def set_status(self, status):
         pass

--- a/mosviz/widgets/share_axis.py
+++ b/mosviz/widgets/share_axis.py
@@ -91,7 +91,10 @@ class SharedAxisHelper(object):
         # too with set_xlim_from_ylim so that the aspect ratio is correct. This
         # will hopefully be fixed in Matplotlib in future. In the mean time, we
         # apply this 'hack' to ylim only since this is what's needed here for
-        # MOSViz
+        # MOSViz. Hopefully, Matplotlib 2.1 will include adjustable='xlim' and
+        # adjustable='ylim' options that will mean this workaround is not
+        # needed, see https://github.com/matplotlib/matplotlib/pull/8700 for
+        # details.
         if self._sharey:
             if axes is self._axes1:
                 self._axes2.set_ylim(*self._axes1.get_ylim())

--- a/mosviz/widgets/share_axis.py
+++ b/mosviz/widgets/share_axis.py
@@ -1,0 +1,92 @@
+# This provides a helper class that can be used to link the limits of axes
+
+from glue.utils.matplotlib import defer_draw
+from glue.utils.decorators import avoid_circular
+
+__all__ = ['SharedAxisHelper']
+
+
+class SharedAxisHelper(object):
+    """
+    A helper class that can be used to enable/disable sharing of the x and/or y
+    axis between two Axes. This is needed because Matplotlib does not have a
+    public API for enabling sharing on axes after initialization, and using
+    events as below is preferable compared to accessing the private _sharex or
+    _sharey attributes on Axes classes since the private attributes are not
+    guaranteed to exist in future.
+    """
+
+    def __init__(self, axes1, axes2, sharex=False, sharey=False):
+        self._axes1 = axes1
+        self._axes2 = axes2
+        self._sharex = sharex
+        self._sharey = sharey
+        self._axes1.callbacks.connect('xlim_changed', self._on_xlim_change)
+        self._axes1.callbacks.connect('ylim_changed', self._on_ylim_change)
+        self._axes2.callbacks.connect('xlim_changed', self._on_xlim_change)
+        self._axes2.callbacks.connect('ylim_changed', self._on_ylim_change)
+
+    @property
+    def sharex(self):
+        return self._sharex
+
+    @sharex.setter
+    def sharex(self, value):
+        self._sharex = value
+        self._on_xlim_change(self._axes1)
+        self._axes1.figure.canvas.draw()
+
+    @property
+    def sharey(self):
+        return self._sharex
+
+    @sharey.setter
+    def sharey(self, value):
+        self._sharey = value
+        self._on_ylim_change(self._axes1)
+        self._axes1.figure.canvas.draw()
+
+    @defer_draw
+    @avoid_circular
+    def _on_xlim_change(self, axes):
+        print('_on_xlim_change', axes, self._sharex)
+        if self._sharex:
+            if axes is self._axes1:
+                self._axes2.set_xlim(*self._axes1.get_xlim())
+                self._axes2.figure.canvas.draw()
+            else:
+                self._axes1.set_xlim(*self._axes2.get_xlim())
+                self._axes1.figure.canvas.draw()
+
+    @defer_draw
+    @avoid_circular
+    def _on_ylim_change(self, axes):
+        print('_on_ylim_change', axes, self._sharey)
+        if self._sharey:
+            if axes is self._axes1:
+                self._axes2.set_ylim(*self._axes1.get_ylim())
+                self._axes2.figure.canvas.draw()
+            else:
+                self._axes1.set_ylim(*self._axes2.get_ylim())
+                self._axes1.figure.canvas.draw()
+
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+
+    subplot = 1
+
+    helpers = []
+
+    for sharex in [False, True]:
+        for sharey in [False, True]:
+            ax1 = fig.add_subplot(2, 4, subplot)
+            ax2 = fig.add_subplot(2, 4, subplot + 1)
+            subplot += 2
+            helper = SharedAxisHelper(ax1, ax2, sharex=sharex, sharey=sharey)
+            helpers.append(helper)
+
+    plt.show()

--- a/mosviz/widgets/share_axis.py
+++ b/mosviz/widgets/share_axis.py
@@ -1,5 +1,7 @@
 # This provides a helper class that can be used to link the limits of axes
 
+from __future__ import print_function, division, absolute_import
+
 from glue.utils.matplotlib import defer_draw
 from glue.utils.decorators import avoid_circular
 

--- a/mosviz/widgets/toolbars.py
+++ b/mosviz/widgets/toolbars.py
@@ -78,12 +78,12 @@ class MOSViewerToolbar(BasicToolbar):
         self.settings_menu = QMenu(self)
 
         # Add lock x axis action
-        self.lock_x_action = QAction("Lock X Axis",
+        self.lock_x_action = QAction("Lock spectral axis",
                                      self.settings_menu)
         self.lock_x_action.setCheckable(True)
 
         # Add lock y axis action
-        self.lock_y_action = QAction("Lock Y Axis",
+        self.lock_y_action = QAction("Lock vertical displacement axis",
                                      self.settings_menu)
         self.lock_y_action.setCheckable(True)
 

--- a/mosviz/widgets/toolbars.py
+++ b/mosviz/widgets/toolbars.py
@@ -1,15 +1,19 @@
+from __future__ import print_function, division, absolute_import
+
 import os
 
 from glue.viewers.common.qt.toolbar import BasicToolbar
-from glue.viewers.common.qt.tool import CheckableTool, Tool
+from glue.viewers.common.qt.tool import Tool
 
-from qtpy.QtWidgets import QAction, QComboBox, QSpacerItem, QMenu, QToolButton, QWidgetAction
+from qtpy.QtWidgets import QAction, QComboBox, QMenu, QToolButton, QWidgetAction
 from qtpy.QtGui import QIcon
 from qtpy.QtCore import Qt
 
 __all__ = ['CyclePreviousTool', 'CycleForwardTool', 'MOSViewerToolbar']
 
+
 class CyclePreviousTool(Tool):
+
     def __init__(self, viewer, toolbar=None):
         super(CyclePreviousTool, self).__init__(viewer=viewer)
         self.tool_id = 'mv:previous'
@@ -24,6 +28,7 @@ class CyclePreviousTool(Tool):
 
 
 class CycleForwardTool(Tool):
+
     def __init__(self, viewer, toolbar=None):
         super(CycleForwardTool, self).__init__(viewer=viewer)
         self.tool_id = 'mv:next'

--- a/mosviz/widgets/viewer_options.py
+++ b/mosviz/widgets/viewer_options.py
@@ -1,10 +1,9 @@
-import os
+from __future__ import print_function, division, absolute_import
 
 from qtpy.QtWidgets import QWidget
 
-from glue.utils.qt.widget_properties import CurrentComboDataProperty
-
 __all__ = ["OptionsWidget"]
+
 
 class OptionsWidget(QWidget):
     def __init__(self, parent=None, data_viewer=None):


### PR DESCRIPTION
This fixes the locking of axes. As a result, for now, the y-axis of the 2D spectrum is just displacement in pixels. The issue is that if the 2D spectrum uses WCSAxes then the spectral axis locking doesn't work because the x values for the 2D spectrum are in pixels and the x values for the 1D spectrum are in world coordinates.

Note that this now relies on the developer of Glue to work correctly. I will release glue v0.10.5 soon with the required fixes, but I think we can already merge this if it otherwise looks good.

One of the things that this PR does is to switch from using private API access in matplotlib for sharing axes to relying on the fully public API. This adds a little code in ``share_axis.py`` but I'm more comfortable relying on public APIs.