### PR TITLE
WIP: Minor ui improvements

### DIFF
--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -38,7 +38,7 @@ __all__ = ['MOSVizViewer']
 
 
 class MOSVizViewer(DataViewer):
-    LABEL = "MosViz Viewer"
+    LABEL = "MOSViz Viewer"
     window_closed = Signal()
     _toolbar_cls = MOSViewerToolbar
 

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -12,6 +12,7 @@ from glue.core import Subset
 from glue.core.exceptions import IncompatibleAttribute
 from glue.viewers.common.qt.data_viewer import DataViewer
 from glue.utils.matplotlib import defer_draw
+from glue.utils.decorators import avoid_circular
 
 from specutils.core.generic import Spectrum1DRef
 
@@ -96,11 +97,25 @@ class MOSVizViewer(DataViewer):
         self.central_widget.horizontal_splitter.setStretchFactor(0, 1)
         self.central_widget.horizontal_splitter.setStretchFactor(1, 2)
 
+        # Keep the left and right splitters in sync otherwise the axes don't line up
+        self.central_widget.left_vertical_splitter.splitterMoved.connect(self._left_splitter_moved)
+        self.central_widget.right_vertical_splitter.splitterMoved.connect(self._right_splitter_moved)
+
         # Set the central widget
         self.setCentralWidget(self.central_widget)
 
         # Define the options widget
         self._options_widget = OptionsWidget()
+
+    @avoid_circular
+    def _right_splitter_moved(self, *args, **kwargs):
+        sizes = self.central_widget.right_vertical_splitter.sizes()
+        self.central_widget.left_vertical_splitter.setSizes(sizes)
+
+    @avoid_circular
+    def _left_splitter_moved(self, *args, **kwargs):
+        sizes = self.central_widget.left_vertical_splitter.sizes()
+        self.central_widget.right_vertical_splitter.setSizes(sizes)
 
     def setup_connections(self):
         """

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -8,7 +8,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.patches import Rectangle
 
 from glue.viewers.image.qt.viewer_widget import StandaloneImageWidget
-
+from glue.viewers.common.viz_client import init_mpl
 try:
     from glue.viewers.common.qt.mpl_toolbar import MatplotlibViewerToolbar
 except ImportError:
@@ -41,7 +41,7 @@ class Line1DWidget(QMainWindow):
         self.addToolBar(self.toolbar)
         self.setCentralWidget(self.central_widget)
 
-        self._axes = self.figure.add_subplot(111)
+        _, self._axes = init_mpl(figure=self.figure)
         self._artists = []
 
     @property


### PR DESCRIPTION
This makes a few small improvements (some as a result of speaking with @kassin today)

* Make it so that the 1D and 2D spectra have axes that line up exactly
* Make it so that the vertical splitter on the left and the right are linked, to make sure the image axes always line up exactly with the 2D spectrum
* Rename MosViz to MOSViz in viewer list

More improvements coming soon