### PR TITLE
Updated glueviz version to 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - GLUEVIZ_VERSION=0.10.4
+        - GLUEVIZ_VERSION=0.11.0
 
 
         # List other runtime dependencies for the package that are available as

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ license = BSD 3-Clause
 url = https://github.com/spacetelescope/mosviz
 edit_on_github = False
 github_project = spacetelescope/mosviz
-install_requires = numpy astropy specutils==0.2.2 glueviz>0.9.0 qtpy
+install_requires = numpy astropy specutils==0.2.2 glueviz>=0.11.0 qtpy
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.0
 


### PR DESCRIPTION
glueviz 0.11.0 is now out though not advertised yet, but we can already start to make sure that things work properly with MOSViz