### PR TITLE
Change glueviz dependency to glue-core.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ license = BSD 3-Clause
 url = https://github.com/spacetelescope/mosviz
 edit_on_github = False
 github_project = spacetelescope/mosviz
-install_requires = numpy astropy specutils==0.2.2 glueviz>=0.11.0 qtpy
+install_requires = numpy astropy specutils==0.2.2 glue-core qtpy
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ license = BSD 3-Clause
 url = https://github.com/spacetelescope/mosviz
 edit_on_github = False
 github_project = spacetelescope/mosviz
-install_requires = numpy astropy specutils==0.2.2 glue-core qtpy
+install_requires = numpy astropy specutils==0.2.2 glue-core>=0.11.0 qtpy
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.0
 


### PR DESCRIPTION
This is necessary to allow building the astroconda package since glueviz was changed to a metapackage.