### PR TITLE
Fix specviz import

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,30 +11,27 @@ environment:
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
 
-      # For this package-template, we include examples of Cython modules,
-      # so Cython is required for testing. If your package does not include
-      # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "Cython"
+      NUMPY_VERSION: "stable"
+      CONDA_DEPENDENCIES: "pyqt numpy astropy glue-core>=0.13 specviz=0.5"
+      PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel
       # "astropy" while builds for astropy LTS with recent numpy versions
       # are in astropy-ci-extras. If your package uses either of these,
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
-      # CONDA_CHANNELS: "astropy-ci-extras astropy"
+      CONDA_CHANNELS: "glueviz/label/dev glueviz astropy-ci-extras astropy"
 
   matrix:
 
-      # We test Python 2.7 and 3.6 because 2.7 is the supported Python 2
-      # release of Astropy and Python 3.6 is the latest Python 3 release.
-
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "stable"
-        NUMPY_VERSION: "stable"
+
+      - PYTHON_VERSION: "3.5"
+        ASTROPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
-        NUMPY_VERSION: "stable"
 
 platform:
     -x64
@@ -49,4 +46,6 @@ install:
 build: false
 
 test_script:
+    - "conda info"
+    - "conda list"
     - "%CMD_IN_ENV% python setup.py test"

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -29,9 +29,12 @@ from astropy.coordinates import SkyCoord
 from astropy.wcs.utils import proj_plane_pixel_area
 
 try:
-    from specviz.external.glue.data_viewer import SpecVizViewer
+    from specviz.third_party.glue.data_viewer import SpecVizViewer
 except ImportError:
-    SpecVizViewer = None
+    try:
+        from specviz.external.glue.data_viewer import SpecVizViewer
+    except ImportError:
+        SpecVizViewer = None
 
 from ..widgets.toolbars import MOSViewerToolbar
 from ..widgets.plots import Line1DWidget, MOSImageWidget, DrawableImageWidget


### PR DESCRIPTION
The previous specviz import didn't work with the latest stable version of specviz so the 'Open in specviz' button didn't work.

Also Fixes #90