### PR TITLE
Use the public API to get categorical labels

### DIFF
--- a/mosviz/data/ui/loader_selection.ui
+++ b/mosviz/data/ui/loader_selection.ui
@@ -16,10 +16,10 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_9">
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Declination</string>
+        <string>1D Spectra</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -36,18 +36,94 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_2">
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_9">
        <property name="text">
-        <string>1D Spectra</string>
+        <string>Declination</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Right Ascension</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QComboBox" name="combosel_slit_dec"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Image Cutouts</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="0" colspan="3">
+      <widget class="QLabel" name="label_status">
+       <property name="text">
+        <string>Status</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="combosel_spectrum1d"/>
+     </item>
      <item row="5" column="1">
       <widget class="QComboBox" name="combosel_cutout"/>
+     </item>
+     <item row="7" column="0" colspan="3">
+      <widget class="Line" name="line_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QComboBox" name="combosel_loader_cutout"/>
+     </item>
+     <item row="4" column="2">
+      <widget class="QComboBox" name="combosel_loader_spectrum2d"/>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Width</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="3">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="0" colspan="3">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Note that the slit is assumed to be aligned with the y-axis of the cutouts</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="2" column="1">
       <widget class="QLabel" name="label_5">
@@ -65,7 +141,13 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="combosel_spectrum2d"/>
+     </item>
      <item row="12" column="1">
+      <widget class="QComboBox" name="combosel_slit_width"/>
+     </item>
+     <item row="13" column="1">
       <widget class="QComboBox" name="combosel_slit_length"/>
      </item>
      <item row="2" column="2">
@@ -100,7 +182,7 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
+     <item row="13" column="0">
       <widget class="QLabel" name="label_11">
        <property name="text">
         <string>Length</string>
@@ -109,9 +191,6 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QComboBox" name="combosel_slit_width"/>
      </item>
      <item row="0" column="0" colspan="3">
       <widget class="QLabel" name="label">
@@ -138,90 +217,24 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QComboBox" name="combosel_spectrum2d"/>
-     </item>
-     <item row="7" column="0" colspan="3">
-      <widget class="Line" name="line_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QComboBox" name="combosel_slit_ra"/>
-     </item>
      <item row="10" column="1">
-      <widget class="QComboBox" name="combosel_slit_dec"/>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="combosel_spectrum1d"/>
-     </item>
-     <item row="5" column="2">
-      <widget class="QComboBox" name="combosel_loader_cutout"/>
+      <widget class="QComboBox" name="combosel_slit_ra"/>
      </item>
      <item row="3" column="2">
       <widget class="QComboBox" name="combosel_loader_spectrum1d"/>
      </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="label_10">
-       <property name="text">
-        <string>Width</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
      <item row="9" column="0">
-      <widget class="QLabel" name="label_8">
+      <widget class="QLabel" name="label_13">
        <property name="text">
-        <string>Right Ascension</string>
+        <string>Source ID</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Image Cutouts</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QComboBox" name="combosel_loader_spectrum2d"/>
-     </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="0" colspan="3">
-      <widget class="QLabel" name="label_12">
-       <property name="text">
-        <string>Note that the slit is assumed to be aligned with the y-axis of the cutouts</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="0" colspan="3">
-      <widget class="QLabel" name="label_status">
-       <property name="text">
-        <string>Status</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
+     <item row="9" column="1">
+      <widget class="QComboBox" name="combosel_source_id"/>
      </item>
     </layout>
    </item>

--- a/mosviz/loaders/loader_selection.py
+++ b/mosviz/loaders/loader_selection.py
@@ -26,6 +26,8 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
                 'categorical': True, 'numeric': False},
                {'property': 'cutout', 'default': 'cutout',
                 'categorical': True, 'numeric': False},
+               {'property': 'source_id', 'default': 'id',
+                'categorical': True, 'numeric': False},
                {'property': 'slit_ra', 'default': 'ra',
                 'categorical': False, 'numeric': True},
                {'property': 'slit_dec', 'default': 'dec',
@@ -42,6 +44,8 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
     spectrum1d = SelectionCallbackProperty()
     spectrum2d = SelectionCallbackProperty()
     cutout = SelectionCallbackProperty()
+
+    source_id = SelectionCallbackProperty()
 
     slit_ra = SelectionCallbackProperty()
     slit_dec = SelectionCallbackProperty()

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -755,14 +755,14 @@ class MOSVizViewer(DataViewer):
         i = self.toolbar.source_select.currentIndex()
         i = self._index_hash(i)
         comp = self.session.data_collection[idx].get_component("comments")
-        return comp._categorical_data[i]
+        return comp.labels[i]
 
     def get_flag(self):
         idx = self.data_idx
         i = self.toolbar.source_select.currentIndex()
         i = self._index_hash(i)
         comp = self.session.data_collection[idx].get_component("flag")
-        return comp._categorical_data[i]
+        return comp.labels[i]
 
     def send_NumericalDataChangedMessage(self):
         idx = self.data_idx
@@ -848,12 +848,12 @@ class MOSVizViewer(DataViewer):
         data = self.session.data_collection[idx]
 
         comp = data.get_component("comments")
-        comp._categorical_data.flags.writeable = True
-        comp._categorical_data[i] = self.input_comments.toPlainText()
+        comp.labels.flags.writeable = True
+        comp.labels[i] = self.input_comments.toPlainText()
 
         comp = data.get_component("flag")
-        comp._categorical_data.flags.writeable = True
-        comp._categorical_data[i] = self.input_flag.text()
+        comp.labels.flags.writeable = True
+        comp.labels[i] = self.input_flag.text()
 
         self.send_NumericalDataChangedMessage()
         self.write_comments()
@@ -886,7 +886,7 @@ class MOSVizViewer(DataViewer):
 
         #Fill in any saved comments:
         meta = data.meta
-        obj_names = data.get_component("id")._categorical_data
+        obj_names = data.get_component("id").labels
 
         if "MOSViz_comments" in meta.keys():
             try:
@@ -928,9 +928,9 @@ class MOSVizViewer(DataViewer):
 
         idx = self.data_idx
         data = self.session.data_collection[idx]
-        save_comments = data.get_component("comments")._categorical_data
-        save_flag = data.get_component("flag")._categorical_data
-        obj_names = data.get_component("id")._categorical_data
+        save_comments = data.get_component("comments").labels
+        save_flag = data.get_component("flag").labels
+        obj_names = data.get_component("id").labels
 
         fn = self.savepath
         folder = os.path.dirname(fn)

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -424,8 +424,8 @@ class MOSVizViewer(DataViewer):
 
         self.toolbar.source_select.clear()
 
-        if len(self.catalog) > 0 and 'id' in self.catalog.colnames:
-            self.toolbar.source_select.addItems(self.catalog['id'][:])
+        if len(self.catalog) > 0 and self.catalog.meta["special_columns"]["source_id"] in self.catalog.colnames:
+            self.toolbar.source_select.addItems(self.catalog[self.catalog.meta["special_columns"]["source_id"]][:])
 
         self.toolbar.source_select.setCurrentIndex(select)
 
@@ -886,7 +886,7 @@ class MOSVizViewer(DataViewer):
 
         #Fill in any saved comments:
         meta = data.meta
-        obj_names = data.get_component("id").labels
+        obj_names = data.get_component(self.catalog.meta["special_columns"]["source_id"]).labels
 
         if "MOSViz_comments" in meta.keys():
             try:
@@ -930,7 +930,7 @@ class MOSVizViewer(DataViewer):
         data = self.session.data_collection[idx]
         save_comments = data.get_component("comments").labels
         save_flag = data.get_component("flag").labels
-        obj_names = data.get_component("id").labels
+        obj_names = data.get_component(self.catalog.meta["special_columns"]["source_id"]).labels
 
         fn = self.savepath
         folder = os.path.dirname(fn)


### PR DESCRIPTION
This fixes compatibility with the latest developer version of glue - before this MOSViz was relying on a private attribute for which no backward-compatibility is guaranteed.