### PR TITLE
Include MOSViz in window title

### DIFF
--- a/mosviz/startup.py
+++ b/mosviz/startup.py
@@ -3,15 +3,20 @@ from __future__ import print_function, division
 from glue.config import startup_action
 
 from mosviz.viewers.mos_viewer import MOSVizViewer
+from mosviz import __version__
 
 
 @startup_action('mosviz')
 def mosviz_setup(session, data_collection):
+
+    # Update the application window title
+    session.application.setWindowTitle('MOSViz v{0} (powered by glue)'.format(__version__))
 
     # Make sure the application is visible first to avoid issues with
     # splitters not being in sync in MOSViz viewer
     session.application.show()
     session.application.app.processEvents()
 
+    # Create MOSViz data viewer for every loaded dataset
     for data in data_collection[:]:
         session.application.new_data_viewer(MOSVizViewer, data=data)


### PR DESCRIPTION
This looks like:

![screen shot 2018-07-16 at 15 04 39](https://user-images.githubusercontent.com/314716/42762981-ad0bcb7c-8909-11e8-929a-3c6450051d90.png)

I thought it would make sense to include 'powered by glue', but let me know if you disagree.

Fixes https://github.com/spacetelescope/mosviz/issues/102