### PR TITLE
Remove support for Python 2.7

### DIFF
--- a/mosviz/_astropy_init.py
+++ b/mosviz/_astropy_init.py
@@ -6,11 +6,7 @@ __all__ = ['__version__', '__githash__', 'test']
 try:
     _ASTROPY_SETUP_
 except NameError:
-    from sys import version_info
-    if version_info[0] >= 3:
-        import builtins
-    else:
-        import __builtin__ as builtins
+    import builtins
     builtins._ASTROPY_SETUP_ = False
 
 try:

--- a/mosviz/loaders/__init__.py
+++ b/mosviz/loaders/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 """
 Data loaders for MOSViz
 """

--- a/mosviz/loaders/loader_selection.py
+++ b/mosviz/loaders/loader_selection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 
 from qtpy import QtWidgets

--- a/mosviz/loaders/utils.py
+++ b/mosviz/loaders/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from glue.config import data_factory
 
 

--- a/mosviz/plugins/__init__.py
+++ b/mosviz/plugins/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import
-
 from .cutout_tool import *
 from .table_generator import *

--- a/mosviz/plugins/cutout_tool.py
+++ b/mosviz/plugins/cutout_tool.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import sys
 import os
 from glob import glob

--- a/mosviz/plugins/table_generator.py
+++ b/mosviz/plugins/table_generator.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import sys
 import os
 from glob import glob

--- a/mosviz/startup.py
+++ b/mosviz/startup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from glue.config import startup_action
 
 from mosviz.viewers.mos_viewer import MOSVizViewer

--- a/mosviz/viewers/__init__.py
+++ b/mosviz/viewers/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import
-
 from .mos_viewer import *

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import os
 from collections import OrderedDict
 

--- a/mosviz/widgets/__init__.py
+++ b/mosviz/widgets/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .plots import *
 from .toolbars import *
 from .viewer_options import *

--- a/mosviz/widgets/plots.py
+++ b/mosviz/widgets/plots.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMainWindow
 

--- a/mosviz/widgets/share_axis.py
+++ b/mosviz/widgets/share_axis.py
@@ -1,7 +1,5 @@
 # This provides a helper class that can be used to link the limits of axes
 
-from __future__ import print_function, division, absolute_import
-
 from glue.utils.matplotlib import defer_draw
 from glue.utils.decorators import avoid_circular
 

--- a/mosviz/widgets/toolbars.py
+++ b/mosviz/widgets/toolbars.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import os
 
 from glue.viewers.common.qt.toolbar import BasicToolbar

--- a/mosviz/widgets/viewer_options.py
+++ b/mosviz/widgets/viewer_options.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from qtpy.QtWidgets import QWidget
 
 __all__ = ["OptionsWidget"]

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ import ah_bootstrap
 from setuptools import setup
 
 # A dirty hack to get around some early import/configurations ambiguities
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
+import builtins
 builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (register_commands, get_debug_option,


### PR DESCRIPTION
This resolves #109. ~It also adds tests for Python 3.7 to the CI configs.~ We can't add tests for 3.7 until   particular dependencies (e.g. `specutils`) provide wheels for 3.7.