### PR TITLE
State resets after each test method

### DIFF
--- a/mosviz/conftest.py
+++ b/mosviz/conftest.py
@@ -74,3 +74,9 @@ def glue_gui():
     app.viewers[0][0].add_data_for_testing(app.data_collection[0])
 
     return app
+
+
+@pytest.fixture(autouse=True)
+def reset_state(glue_gui):
+    reset_mosviz = glue_gui.viewers[0][0]
+    reset_mosviz.toolbar.source_select.setCurrentIndex(0)

--- a/mosviz/conftest.py
+++ b/mosviz/conftest.py
@@ -78,5 +78,11 @@ def glue_gui():
 
 @pytest.fixture(autouse=True)
 def reset_state(glue_gui):
+    # This yields the test itself
+    yield
+
+    # Returns the applications to this state between tests
+    # Currently, this only changes the index of the combobox back to 0.
+    # TODO: In the future, this may need to be more robust
     reset_mosviz = glue_gui.viewers[0][0]
     reset_mosviz.toolbar.source_select.setCurrentIndex(0)

--- a/mosviz/viewers/tests/test_mos_viewer.py
+++ b/mosviz/viewers/tests/test_mos_viewer.py
@@ -45,19 +45,3 @@ def test_ending_state(glue_gui):
     mosviz_gui.toolbar.cycle_previous_action.trigger()
     assert source_combo.currentText() == source_combo.itemText(source_combo.count() - 2)
     assert mosviz_gui.toolbar.cycle_next_action.isEnabled() == True
-
-
-def test_make_it_look_like_more_tests(glue_gui):
-    """
-    This test will do something useful in the future
-    :param qtbot:
-    :param glue_gui:
-    :return:
-    """
-    mosviz_gui = get_mosviz_gui(glue_gui)
-    source_combo = mosviz_gui.toolbar.source_select
-    assert mosviz_gui.toolbar.cycle_next_action.isEnabled() == True
-
-    mosviz_gui.toolbar.cycle_next_action.trigger()
-    assert source_combo.currentText() == source_combo.itemText(source_combo.count() - 1)
-    assert mosviz_gui.toolbar.cycle_next_action.isEnabled() == False


### PR DESCRIPTION
This is a small change but it allows developers to write tests with a reset state of MOSViz each time.