### PR TITLE
Handle selections with only one type of spectra

### DIFF
--- a/mosviz/tests/data/deimos_mosviz.tbl
+++ b/mosviz/tests/data/deimos_mosviz.tbl
@@ -21,3 +21,4 @@ deimos_12008179 214.33785 52.454369 spec1D/spec1d.1203.063.12008179.fits spec2D/
 deimos_12012573 214.34313 52.53112 spec1D/spec1d.1205.091.12012573.fits spec2D/slit.1205.091R.fits.gz cutouts/12012573.acs.v_6ac_.fits 0.2 3.3 0.66
 deimos_12016058 214.52242 52.580972 spec1D/spec1d.1208.055.12016058.fits spec2D/slit.1208.055R.fits.gz cutouts/12016058.acs.v_6ac_.fits 0.2 3.3 0.66
 deimos_12020734 214.49056 52.632246 spec1D/spec1d.1209.080.12020734.fits spec2D/slit.1209.080R.fits.gz cutouts/12020734.acs.v_6ac_.fits 0.2 3.3 0.66
+deimos_None 214.49056 52.632246 None None None 0.2 3.3 0.66

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -34,7 +34,7 @@ except ImportError:
         SpecVizViewer = None
 
 from ..widgets.toolbars import MOSViewerToolbar
-from ..widgets.plots import Line1DWidget, MOSImageWidget, DrawableImageWidget
+from ..widgets.plots import Line1DWidget, Spectrum2DWidget, DrawableImageWidget
 from ..loaders.loader_selection import confirm_loaders_and_column_names
 from ..loaders.utils import SPECTRUM1D_LOADERS, SPECTRUM2D_LOADERS, CUTOUT_LOADERS, LEVEL2_LOADERS
 from ..widgets.viewer_options import OptionsWidget
@@ -87,7 +87,7 @@ class MOSVizViewer(DataViewer):
         loadUi(path, self.central_widget)
 
         self.image_widget = DrawableImageWidget(slit_controller=self.slit_controller)
-        self.spectrum2d_widget = MOSImageWidget()
+        self.spectrum2d_widget = Spectrum2DWidget()
         self.spectrum1d_widget = Line1DWidget()
 
         # Set up helper for sharing axes. SharedAxisHelper defaults to no sharing
@@ -575,7 +575,6 @@ class MOSVizViewer(DataViewer):
         Processes a row in the MOS catalog by first loading the data set,
         updating the stored data components, and then rendering the data on
         the visible MOSViz viewer plots.
-
         Parameters
         ----------
         row : :class:`astropy.table.Row`
@@ -585,51 +584,39 @@ class MOSVizViewer(DataViewer):
 
         self.current_row = row
 
-        # Level 2 is optional
-        is_level2 = "level2" in self.catalog.meta["loaders"]
-
         # Get loaders
         loader_spectrum1d = SPECTRUM1D_LOADERS[self.catalog.meta["loaders"]["spectrum1d"]]
         loader_spectrum2d = SPECTRUM2D_LOADERS[self.catalog.meta["loaders"]["spectrum2d"]]
         loader_cutout = CUTOUT_LOADERS[self.catalog.meta["loaders"]["cutout"]]
-        if is_level2:
-            loader_level2 = LEVEL2_LOADERS[self.catalog.meta["loaders"]["level2"]]
 
         # Get column names
         colname_spectrum1d = self.catalog.meta["special_columns"]["spectrum1d"]
         colname_spectrum2d = self.catalog.meta["special_columns"]["spectrum2d"]
         colname_cutout = self.catalog.meta["special_columns"]["cutout"]
-        if is_level2:
-            colname_level2 = self.catalog.meta["special_columns"]["level2"]
 
-        # Get mandatory data
-        spec1d_data = loader_spectrum1d(row[colname_spectrum1d])
-        spec2d_data = loader_spectrum2d(row[colname_spectrum2d])
+        spec1d_basename = os.path.basename(row[colname_spectrum1d])
+        if spec1d_basename == "None":
+            spec1d_data = None
+        else:
+            spec1d_data = loader_spectrum1d(row[colname_spectrum1d])
+
+        spec2d_basename = os.path.basename(row[colname_spectrum2d])
+        if spec2d_basename == "None":
+            spec2d_data = None
+        else:
+            spec2d_data = loader_spectrum2d(row[colname_spectrum2d])
+
+        image_basename = os.path.basename(row[colname_cutout])
+        if image_basename == "None":
+            image_data = None
+        else:
+            image_data = loader_cutout(row[colname_cutout])
 
         self._update_data_components(spec1d_data, key='spectrum1d')
         self._update_data_components(spec2d_data, key='spectrum2d')
+        self._update_data_components(image_data, key='cutout')
 
-        # See if optional data exists; if so, ingest them.
-        basename_cutout = os.path.basename(row[colname_cutout])
-        if basename_cutout:
-            image_data = loader_cutout(row[colname_cutout])
-            self._update_data_components(image_data, key='cutout')
-        else:
-            image_data = None
-
-        level2_data = None
-        if is_level2:
-            basename_level2 = os.path.basename(row[colname_level2])
-            if basename_level2:
-                level2_data = loader_level2(row[colname_level2])
-                self._update_data_components(level2_data, key='level2')
-
-        # Keep data that will be used to refresh the 2D spectrum widget.
-        self.spec2d_data = spec2d_data
-        self.level2_data = level2_data
-
-        # Plot
-        self.render_data(row, spec1d_data, spec2d_data, image_data, level2_data)
+        self.render_data(row, spec1d_data, spec2d_data, image_data)
 
     def load_exposure(self, index):
         '''
@@ -658,7 +645,6 @@ class MOSVizViewer(DataViewer):
         Update the data components that act as containers for the displayed
         data in the MOSViz viewer. This obviates the need to keep creating new
         data components.
-
         Parameters
         ----------
         data : :class:`glue.core.data.Data`
@@ -668,11 +654,16 @@ class MOSVizViewer(DataViewer):
         """
         cur_data = self._loaded_data.get(key, None)
 
-        if cur_data is None:
+        if cur_data is not None and data is None:
+            self._loaded_data[key] = None
+            self.session.data_collection.remove(cur_data)
+        elif cur_data is None and data is not None:
             self._loaded_data[key] = data
             self.session.data_collection.append(data)
-        else:
+        elif data is not None:
             cur_data.update_values_from_data(data)
+        else:
+            return
 
     def add_slit(self, row=None, width=None, length=None):
         if row is None:
@@ -726,6 +717,8 @@ class MOSVizViewer(DataViewer):
 
             self.spectrum1d_widget.axes.set_xlabel("Wavelength [{}]".format(disp_unit))
             self.spectrum1d_widget.axes.set_ylabel("Flux [{}]".format(flux_unit))
+        else:
+            self.spectrum1d_widget.no_data()
 
         if image_data is not None:
             if not self.image_widget.isVisible():
@@ -775,6 +768,8 @@ class MOSVizViewer(DataViewer):
             xp, yp = skycoord.to_pixel(wcs)
 
             self._load_spectrum2d_widget(dy, yp, image_data, spec2d_data, level2_data)
+        else:
+            self.spectrum2d_widget.no_data()
 
         # Clear the meta information widget
         # NOTE: this process is inefficient

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -756,7 +756,7 @@ class MOSVizViewer(DataViewer):
 
         # We are repurposing the spectrum 2d widget to handle the display of both
         # the level 3 and level 2 spectra.
-        if spec2d_data is not None or level2d_data is not None:
+        if spec2d_data is not None or level2_data is not None:
 
             # These are probably retrievable from the slit controller.
             scale = np.sqrt(proj_plane_pixel_area(wcs)) * 3600.

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -575,9 +575,10 @@ class MOSVizViewer(DataViewer):
         Processes a row in the MOS catalog by first loading the data set,
         updating the stored data components, and then rendering the data on
         the visible MOSViz viewer plots.
+
         Parameters
         ----------
-        row : :class:`astropy.table.Row`
+        row : `astropy.table.Row`
             A row object representing a row in the MOS catalog. Each key
             should be a column name.
         """


### PR DESCRIPTION
Closes #80 
This PR introduces code that handles selections with no spectra (1D and/or 2D). It also adds a line to the deimos table that has `None` for the cutout, spectrum 1D and spectrum 2D.

**Selection without a cutout, spectrum 1D and spectrum 2D:**
MOSViz Table line: `deimos_None 214.49056 52.632246 None None None 0.2 3.3 0.66`
MOSVIz Viewer:
<img width="1354" alt="screen shot 2018-09-20 at 12 04 53 pm" src="https://user-images.githubusercontent.com/10345916/45831455-6db9a280-bccd-11e8-8358-0114b8822868.png">

CC: @hcferguson @kassin 