### PR TITLE
Fix 'Open in Specviz' and error when closing MOSViz/Glue

### DIFF
--- a/mosviz/cli.py
+++ b/mosviz/cli.py
@@ -94,4 +94,4 @@ def main(argv=sys.argv):
 
     ga.run_startup_action('mosviz')
 
-    sys.exit(ga.start(maximized=True))
+    ga.start(maximized=True)

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -564,8 +564,8 @@ class MOSVizViewer(DataViewer):
             self.toolbar.exposure_next_action.setDisabled(False)
 
     def _open_in_specviz(self):
-        _specviz_instance = self.session.application.new_data_viewer(
-            SpecvizDataViewer)
+        self._specviz_instance = self.session.application.new_data_viewer(SpecvizDataViewer)
+        self._specviz_instance.add_data(self._loaded_data['spectrum1d'])
 
     def load_selection(self, row):
         """

--- a/mosviz/viewers/mos_viewer.py
+++ b/mosviz/viewers/mos_viewer.py
@@ -26,12 +26,9 @@ from astropy.coordinates import SkyCoord
 from astropy.wcs.utils import proj_plane_pixel_area
 
 try:
-    from specviz.third_party.glue.data_viewer import SpecVizViewer
+    from specviz.third_party.glue.viewer import SpecvizDataViewer
 except ImportError:
-    try:
-        from specviz.external.glue.data_viewer import SpecVizViewer
-    except ImportError:
-        SpecVizViewer = None
+    SpecvizDataViewer = None
 
 from ..widgets.toolbars import MOSViewerToolbar
 from ..widgets.plots import Line1DWidget, Spectrum2DWidget, DrawableImageWidget
@@ -167,7 +164,7 @@ class MOSVizViewer(DataViewer):
             lambda ind: self._set_exposure_navigation(ind))
 
         # Connect the specviz button
-        if SpecVizViewer is not None:
+        if SpecvizDataViewer is not None:
             self.toolbar.open_specviz.triggered.connect(
                 lambda: self._open_in_specviz())
         else:
@@ -568,7 +565,7 @@ class MOSVizViewer(DataViewer):
 
     def _open_in_specviz(self):
         _specviz_instance = self.session.application.new_data_viewer(
-            SpecVizViewer)
+            SpecvizDataViewer)
 
     def load_selection(self, row):
         """


### PR DESCRIPTION
This does two separate things:

* It fixes the following error when closing glue once a MOSViz viewer has been opened:

```
Traceback (most recent call last):
  File "/Users/nearl/anaconda3/envs/mosviz_dev/lib/python3.7/site-packages/glue/utils/qt/decorators.py", line 63, in decorated
    return f(*args, **kwargs)
  File "/Users/nearl/projects/mosviz/mosviz/cli.py", line 97, in main
    sys.exit(ga.start(maximized=True))
SystemExit: 0
```

(basically we shouldn't call ``sys.exit`` inside the Qt application)

* It updates the imports for the SpecViz viewer. In addition, it now automatically adds the data to the viewer. However, currently the SpecViz viewer will sometimes complain that the data is not a spectrum, because the issue is that the way we load the spectra in MOSViz, ``data.coords`` is just a ``Coordinates`` not a ``WCSCoordinates``. I'll try and tackle this next, but in the mean time it's already be good to merge this PR.

Note that this makes MOSViz compatible only with the new dev SpecViz, which I think is fine?