### PR TITLE
Removed old dependency test for numpy and astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11 ASTROPY_VERSION=3.0
+          env: PYTHON_VERSION=3.5
 
         # Try numpy pre-release
         - os: linux


### PR DESCRIPTION
The travis testing against numpy=1.11 and astropy=3.0 is not correct, the test should be against stable. This is after a discussion with @drdavella who had seen this before. 

Fixes #173