### PR TITLE
Update CI matrix, use tox for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,49 +14,24 @@ sudo: false
 #
 # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
 
-addons:
-    apt:
-        packages:
-            - graphviz
-
 env:
     global:
 
         # The following versions are the 'default' for tests, unless
-        # overridden underneath. They are defined here in order to save having
+        # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
-        - MAIN_CMD='python setup.py'
-        - SETUP_CMD='test'
-        - EVENT_TYPE='pull_request push'
-        - GLUEVIZ_VERSION=0.11.0
-
-
-        # List other runtime dependencies for the package that are available as
-        # conda packages here.
-        - CONDA_DEPENDENCIES='glueviz matplotlib cython pyqt scipy'
-
-        # List other runtime dependencies for the package that are available as
-        # pip packages here.
-        - PIP_DEPENDENCIES='sphinx_rtd_theme sphinx_automodapi qtpy codecov regions>=0.3 specviz>=0.6.2'
-
-        # Conda packages for affiliated packages are hosted in channel
-        # "astropy" while builds for astropy LTS with recent numpy versions
-        # are in astropy-ci-extras. If your package uses either of these,
-        # add the channels to CONDA_CHANNELS along with any other channels
-        # you want to use.
-        - CONDA_CHANNELS='astropy-ci-extras astropy glueviz'
-
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
+        - TOX_CMD='tox --'
+        - TOX_ARGS='--remote-data'
         - SETUP_XVFB=True
 
     matrix:
-        # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        # Make sure that installation does not fail
+        - TOXENV='py36' TOX_CMD='tox --notest' TOX_ARGS=''
+        # Make sure README will display properly on pypi
+        - TOXENV='checkdocs'
+        # Run a test with stable dependencies
+        - TOXENV='py36'
+        - TOXENV='py37'
 
 matrix:
 
@@ -64,68 +39,54 @@ matrix:
     fast_finish: true
 
     include:
-        # Try MacOS X
-        - os: osx
-          env: SETUP_CMD='test'
+        # Do a coverage test
+        - env: TOXENV='coverage' TOX_ARGS=''
 
-        # Do a coverage test.
-        - os: linux
-          env: SETUP_CMD='test --coverage'
+        # Perform a sanity check of packaging using twine
+        - env: TOXENV='twine' TOX_ARGS=''
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - os: linux
-          env: SETUP_CMD='build_docs -w' SPHINX_VERSION='<1.6'
+        - env: TOXENV='docbuild' TOX_ARGS=''
 
-        # Now try Astropy dev and LTS vesions with the latest 3.x
-        - os: linux
-          env: ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
+        # Do a code style check
+        - env: TOXENV='style' TOX_ARGS=''
 
-        # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different
-        # versions of Python, we can vary Python and Numpy versions at the same
-        # time.
+        # Try MacOS X and Windows
+        - os: osx
+          env: TOXENV='py36'
 
-        - os: linux
-          env: PYTHON_VERSION=3.5
+        - os: windows
+          env: TOXENV='py36'
 
-        # Try numpy pre-release
-        - os: linux
-          env: NUMPY_VERSION=prerelease
-               EVENT_TYPE='pull_request push cron'
+        # Try building against Astropy dev
+        - env: TOXENV='py37-astrodev'
 
-        # Do a PEP8 test with pycodestyle
-        - os: linux
-          env: MAIN_CMD='pycodestyle mosviz --count' SETUP_CMD=''
+        # Test against numpy dev
+        - env: TOXENV='py37-numpydev'
+
+        # Test against oldest supported version of Glue
+        - env: TOXENV='py36-glueold'
+
+        # Test against latest development version of Glue
+        - env: TOXENV='py37-gluedev'
+
+    allow_failures:
+        - env: TOXENV='style' TOX_ARGS=''
+        - env: TOXENV='py37-astrodev'
+        - env: TOXENV='py37-numpydev'
+        - env: TOXENV='py37-gluedev'
+
+        - os: windows
+          env: TOXENV='py36'
 
 install:
-
-    # We now use the ci-helpers package to set up our testing environment.
-    # This is done by using Miniconda and then using conda and pip to install
-    # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
-    # which should be space-delimited lists of package names. See the README
-    # in https://github.com/astropy/ci-helpers for information about the full
-    # list of environment variables that can be used to customize your
-    # environment. In some cases, ci-helpers may not offer enough flexibility
-    # in how to install a package, in which case you can have additional
-    # commands in the install: section below.
-
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-
-    # As described above, using ci-helpers, you should be able to set up an
-    # environment with dependencies installed using conda and pip, but in some
-    # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python
-    # dependencies). Therefore, you can also include commands below (as
-    # well as at the start of the install section or in the before_install
-    # section if they are needed before setting up conda) to install any
-    # other dependencies.
+    - pip install tox tox-conda
 
 script:
-   - $MAIN_CMD $SETUP_CMD
-
-after_success:
-    - if [[ $SETUP_CMD == *coverage* ]]; then codecov; fi
+   - conda info
+   - $TOX_CMD $TOX_ARGS
+   - find mosviz -name "*.ui" -exec grep "pointsize" {} \; >& font.log
+   - test ! -s font.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ sudo: false
 env:
     global:
 
+        # This is the Python version that will be used by the parent conda
+        # environment, but it will not be used in the test environments
+        # themselves.
+        - PYTHON_VERSION=3.6
+
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,16 +30,10 @@ import os
 import sys
 
 try:
-    import astropy_helpers
+    from sphinx_astropy.conf.v1 import *  # noqa
 except ImportError:
-    # Building from inside the docs/ directory?
-    if os.path.basename(os.getcwd()) == 'docs':
-        a_h_path = os.path.abspath(os.path.join('..', 'astropy_helpers'))
-        if os.path.isdir(a_h_path):
-            sys.path.insert(1, a_h_path)
-
-# Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+    print('ERROR: the documentation requires the sphinx-astropy package to be installed')
+    sys.exit(1)
 
 # Get configuration information from setup.cfg
 try:
@@ -84,13 +78,10 @@ copyright = '{0}, {1}'.format(
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-__import__(setup_cfg['package_name'])
-package = sys.modules[setup_cfg['package_name']]
-
 # The short X.Y version.
-version = package.__version__.split('-', 1)[0]
+version = setup_cfg['version'].split('-', 1)[0]
 # The full version, including alpha/beta/rc tags.
-release = package.__version__
+release = setup_cfg['version']
 
 
 # -- Options for HTML output --------------------------------------------------
@@ -154,23 +145,6 @@ latex_documents = [('index', project + '.tex', project + u' Documentation',
 # (source start file, name, description, authors, manual section).
 man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
-
-
-# -- Options for the edit_on_github extension ---------------------------------
-
-if eval(setup_cfg.get('edit_on_github')):
-    extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
-
-    versionmod = __import__(setup_cfg['package_name'] + '.version')
-    edit_on_github_project = setup_cfg['github_project']
-    if versionmod.version.release:
-        edit_on_github_branch = "v" + versionmod.version.version
-    else:
-        edit_on_github_branch = "master"
-
-    edit_on_github_source_root = ""
-    edit_on_github_doc_root = "docs"
-
 
 intersphinx_mapping['glue'] = ('https://glueviz.readthedocs.org/en/stable', None)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,84 @@
+[testenv]
+deps=
+    pytest
+    pytest-qt
+    pytest-sugar
+    pytest-astropy
+    pytest-faulthandler
+    astrodev: git+git://github.com/astropy/astropy
+    numpydev: git+git://github.com/numpy/numpy
+# These are the minimum dependencies required in order to set up our conda
+# environment to enable the PyQt GUI
+conda_deps=
+    pyqt
+    matplotlib
+    glueold: glue-core=0.13
+    gluedev: glue-core
+    astrodev,numpydev: cython
+conda_channels=
+    glueold: glueviz
+    gluedev: glueviz/label/dev
+passenv= DISPLAY
+commands=
+    pytest {posargs}
+
+[testenv:egg_info]
+deps=
+conda_deps=
+commands=
+    python setup.py egg_info
+
+[testenv:twine]
+basepython= python3.6
+deps=
+    twine
+conda_deps=
+commands=
+    twine check {distdir}/*
+
+[testenv:docbuild]
+basepython= python3.6
+deps=
+    sphinx-astropy
+    sphinx_rtd_theme
+conda_deps=
+    sphinx
+    graphviz
+    matplotlib
+commands=
+    python setup.py build_docs -w
+
+[testenv:checkdocs]
+basepython= python3.6
+deps=
+    collective.checkdocs
+    pygments
+commands=
+    python setup.py checkdocs
+
+[testenv:style]
+basepython= python3.6
+conda_deps=
+    flake8
+commands=
+    flake8 mosviz --count
+
+[testenv:coverage]
+basepython= python3.6
+deps=
+    pytest
+    pytest-qt
+    pytest-sugar
+    pytest-astropy
+    pytest-faulthandler
+    codecov
+conda_deps=
+    pyqt
+    matplotlib
+    coverage
+commands=
+    coverage run --source=mosviz --rcfile={toxinidir}/mosviz/tests/coveragerc \
+                 -m pytest --remote-data
+    coverage report -m
+    codecov -e TOXENV
+passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -42,11 +42,13 @@ deps=
     sphinx-astropy
     sphinx_rtd_theme
 conda_deps=
+    pyqt
     sphinx
     graphviz
     matplotlib
 commands=
-    python setup.py build_docs -w
+    sphinx-build -W docs build/docs
+skipsdist=True
 
 [testenv:checkdocs]
 basepython= python3.6


### PR DESCRIPTION
This resolves #162 by adding tests to the CI matrix for both Py36 and Py37.

It also performs some cleanup on the doc build in order to allow it to run without the need for `astropy_helpers`. The doc build gets tested as part of the CI run.