### PR TITLE
Register glue plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ install_requires =
 [options.entry_points]
 gui_scripts =
     mosviz = mosviz.cli:main
+glue.plugins =
+    mosviz = mosviz:setup
 
 [options.extras_require]
 tests = pytest-astropy


### PR DESCRIPTION
This registers `moszviz` as a plugin for `glue`. It resolves #185.