### PR TITLE
Fix loader ui title and lock the size of the text display

### DIFF
--- a/mosviz/data/ui/loader_selection.ui
+++ b/mosviz/data/ui/loader_selection.ui
@@ -134,7 +134,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Column</string>
+        <string>Table Column</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/mosviz/data/ui/loader_selection.ui
+++ b/mosviz/data/ui/loader_selection.ui
@@ -200,6 +200,12 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>436</width>
+         <height>104</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <weight>50</weight>
@@ -296,4 +302,3 @@
  <resources/>
  <connections/>
 </ui>
-

--- a/mosviz/loaders/loader_selection.py
+++ b/mosviz/loaders/loader_selection.py
@@ -72,6 +72,8 @@ class LoaderSelectionDialog(QtWidgets.QDialog, HasCallbackProperties):
 
         self.ui = load_ui('loader_selection.ui', self, directory=UI_DIR)
 
+        self.setWindowTitle("Loader Selection")
+
         # By defult, ui is built for level 2 data. Must be
         # re-configured for level 3-only data.
         if not self.is_level2:


### PR DESCRIPTION
closes #192 #187 #191 

- [x] Add title to loader dialog: "Loader Selection" #192 

- [x] Avoid squishing instruction #187

- [x]  Rename "Column" -> "Table Column" #191 

<img width="591" alt="screen shot 2019-03-05 at 7 35 46 pm" src="https://user-images.githubusercontent.com/10345916/53847317-350d3d00-3f7e-11e9-9783-161ec46a849a.png">

