### PR TITLE
Rename level2 Data components

### DIFF
--- a/mosviz/loaders/jwst_loaders.py
+++ b/mosviz/loaders/jwst_loaders.py
@@ -22,7 +22,7 @@ def nirspec_spectrum1d_reader(file_name):
     with fits.open(file_name) as hdulist:
         header = hdulist['PRIMARY'].header
 
-    tab = Table.read(file_name)
+    tab = Table.read(file_name, hdu=1)
 
     data = Data(label="1D Spectrum")
     data.header = header
@@ -77,10 +77,10 @@ def nirspec_level2_reader(file_name):
     data = Data(label="2D Spectra")
     data.header = hdulist[ext].header
     data.coords = coordinates_from_header(hdulist[ext].header)
-    data.add_component(hdulist[ext].data, 'Flux')
+    data.add_component(hdulist[ext].data, 'Level2 Flux')
 
     # TODO: update uncertainty once data model becomes clear
-    data.add_component(np.sqrt(hdulist[ext + 2].data), 'Uncertainty')
+    data.add_component(np.sqrt(hdulist[ext + 2].data), 'Level2 Uncertainty')
 
     hdulist.close()
 


### PR DESCRIPTION
fixes #209 

- [x] Renames level2 Data components by prepending "Level 2"

<img width="850" alt="screen shot 2019-03-05 at 8 02 09 pm" src="https://user-images.githubusercontent.com/10345916/53848251-9b478f00-3f81-11e9-9aa5-bdc0d7b9900b.png">