### PR TITLE
Updates to make mosviz pip-installable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ os:
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds. A full list of packages
-# that can be included can be found here:
-#
-# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
+# The apt packages below are needed for sphinx builds, which can no longer
+# be installed with sudo apt-get.
+addons:
+    apt:
+        packages:
+            - graphviz
 
 env:
     global:

--- a/mosviz/__init__.py
+++ b/mosviz/__init__.py
@@ -13,6 +13,12 @@ from ._astropy_init import *
 import sys
 from pkg_resources import get_distribution, DistributionNotFound
 
+# This *must* occur before any imports from glue. It prevents the "python must
+# be installed as a framework" error that occurs on OSX. Since we now
+# explicitly depend on PyQt5, we use it as the mpl backend.
+import matplotlib as mpl
+mpl.use('Qt5Agg')
+
 from .mosviz_data_factory import *
 
 try:

--- a/mosviz/conftest.py
+++ b/mosviz/conftest.py
@@ -63,32 +63,34 @@ from .viewers.mos_viewer import MOSVizViewer
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'tests', 'data')
 DEIMOSTABLE = os.path.join(TEST_DATA_DIR, 'deimos_mosviz.tbl')
 
-@pytest.fixture(scope='session')
-def glue_gui():
 
-    d = data_factories.load_data(DEIMOSTABLE)
-    dc = DataCollection([])
-    dc.append(d)
+if not os.environ.get('JWST_DATA_TEST', False):
+    @pytest.fixture(scope='session')
+    def glue_gui():
 
-    # Creates glue instance
-    app = GlueApplication(dc)
-    app.setVisible(True)
+        d = data_factories.load_data(DEIMOSTABLE)
+        dc = DataCollection([])
+        dc.append(d)
 
-    # Adds data to the MosVizViewer
-    app.new_data_viewer(MOSVizViewer)
-    app.viewers[0][0].add_data_for_testing(app.data_collection[0])
+        # Creates glue instance
+        app = GlueApplication(dc)
+        app.setVisible(True)
 
-    return app
+        # Adds data to the MosVizViewer
+        app.new_data_viewer(MOSVizViewer)
+        app.viewers[0][0].add_data_for_testing(app.data_collection[0])
+
+        return app
 
 
-@pytest.fixture(autouse=True)
-def reset_state(glue_gui):
-    # This yields the test itself
-    yield
+    @pytest.fixture(autouse=True)
+    def reset_state(glue_gui):
+        # This yields the test itself
+        yield
 
-    # Returns the applications to this state between tests
-    # Currently, this only changes the index of the comboboxes back to 0.
-    # TODO: In the future, this may need to be more robust
-    reset_mosviz = glue_gui.viewers[0][0]
-    reset_mosviz.toolbar.source_select.setCurrentIndex(0)
-    reset_mosviz.toolbar.exposure_select.setCurrentIndex(0)
+        # Returns the applications to this state between tests
+        # Currently, this only changes the index of the comboboxes back to 0.
+        # TODO: In the future, this may need to be more robust
+        reset_mosviz = glue_gui.viewers[0][0]
+        reset_mosviz.toolbar.source_select.setCurrentIndex(0)
+        reset_mosviz.toolbar.exposure_select.setCurrentIndex(0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ python_requires = >=3.6
 include_package_data = True
 setup_requires = setuptools_scm
 install_requires =
+    pyqt5<5.12
     numpy>=1.16
     astropy>=3.1
     glue-core>=0.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     pyqt5<5.12
     numpy>=1.16
     astropy>=3.1
-    glue-core>=0.13.0
+    glue-core>=0.14
     regions>=0.3
     specviz>=0.6.2
     qtpy

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,6 @@ deps=
 # These are the minimum dependencies required in order to set up our conda
 # environment to enable the PyQt GUI
 conda_deps=
-    pyqt
-    matplotlib
     glueold: glue-core=0.13
     gluedev: glue-core
     astrodev,numpydev: cython
@@ -48,11 +46,9 @@ basepython= python3.6
 deps=
     sphinx-astropy
     sphinx_rtd_theme
-conda_deps=
-    pyqt
     sphinx
     graphviz
-    matplotlib
+conda_deps=
 commands=
     sphinx-build -W docs build/docs
 skipsdist=True
@@ -62,6 +58,7 @@ basepython= python3.6
 deps=
     collective.checkdocs
     pygments
+conda_deps=
 commands=
     python setup.py checkdocs
 
@@ -72,8 +69,9 @@ commands=
 
 [testenv:style]
 basepython= python3.6
-conda_deps=
+deps=
     flake8
+conda_deps=
 commands=
     flake8 mosviz --count
 
@@ -86,10 +84,8 @@ deps=
     pytest-astropy
     pytest-faulthandler
     codecov
-conda_deps=
-    pyqt
-    matplotlib
     coverage
+conda_deps=
 commands=
     coverage run --source=mosviz --rcfile={toxinidir}/mosviz/tests/coveragerc \
                  -m pytest --remote-data


### PR DESCRIPTION
This adds `pyqt5` to install_requires so it does not need to be installed by `conda`. It also addresses the issue that occurs on some OSX machines where `matplotlib` complains about Python not being installed as a framework.