### PR TITLE
Fix version of tox to work around upstream bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ matrix:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-    - pip install tox tox-conda
+    - pip install "tox~=3.7.0" tox-conda
 
 script:
    - conda info


### PR DESCRIPTION
There is a bug in tox that is causing a conflict with tox-conda (see tox-dev/tox-conda#15). This PR adds a workaround to avoid the error in our CI runs.