### PR TITLE
Add Deprecation Warning to Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Current Status
 --------------
 
-Please note that this version of MOSViz is no longer being actively supported
-or maintained. The functionality of MOSViz is now available and being actively
+Please note that this version of MOSViz is **no longer being actively supported
+or maintained**. The functionality of MOSViz is now available and being actively
 developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 MOS Visualization Tool

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Current Status
 
 Please note that this version of MOSViz is no longer being actively supported
 or maintained. The functionality of MOSViz is now available and being actively
-developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`.
+developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 MOS Visualization Tool
 ----------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of Specviz is **no longer being actively supported
+      or maintained**. The functionality of Specviz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 API
 ===
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 .. DANGER:: 
 
-      Please note that this version of Specviz is **no longer being actively supported
-      or maintained**. The functionality of Specviz is now available and being actively
+      Please note that this version of MOSViz is **no longer being actively supported
+      or maintained**. The functionality of MOSViz is now available and being actively
       developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 API

--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of Specviz is **no longer being actively supported
+      or maintained**. The functionality of Specviz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 **************************************
 Overview of Basic MOSViz Functionality
 **************************************

--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -1,7 +1,7 @@
 .. DANGER:: 
 
-      Please note that this version of Specviz is **no longer being actively supported
-      or maintained**. The functionality of Specviz is now available and being actively
+      Please note that this version of MOSViz is **no longer being actively supported
+      or maintained**. The functionality of MOSViz is now available and being actively
       developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 **************************************

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of Specviz is **no longer being actively supported
+      or maintained**. The functionality of Specviz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 ***************************
 Getting Started with MOSViz
 ***************************

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -1,7 +1,7 @@
 .. DANGER:: 
 
-      Please note that this version of Specviz is **no longer being actively supported
-      or maintained**. The functionality of Specviz is now available and being actively
+      Please note that this version of MOSViz is **no longer being actively supported
+      or maintained**. The functionality of MOSViz is now available and being actively
       developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 ***************************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@ MOSViz: Visualization Tool for Multi-object Spectroscopy
 
 .. DANGER:: 
 
-      Please note that this version of Specviz is **no longer being actively supported
-      or maintained**. The functionality of Specviz is now available and being actively
+      Please note that this version of MOSViz is **no longer being actively supported
+      or maintained**. The functionality of MOSViz is now available and being actively
       developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 MOSViz is a quick-look analysis and visualization tool for multi-object spectroscopy (MOS).  It is designed to work with pipeline output: spectra and associated images, or just with spectra.  MOSViz is created to work with data from any telescope/instrument, but is built with the micro-shutter array (MSA) on the JWST/NIRSpec spectrograph and the JWST/NIRCam imager in mind.  As such, MOSViz has some features specific to NIRSpec and NIRCam data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,12 @@
 MOSViz: Visualization Tool for Multi-object Spectroscopy
 ########################################################
 
+.. DANGER:: 
+
+      Please note that this version of Specviz is **no longer being actively supported
+      or maintained**. The functionality of Specviz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 MOSViz is a quick-look analysis and visualization tool for multi-object spectroscopy (MOS).  It is designed to work with pipeline output: spectra and associated images, or just with spectra.  MOSViz is created to work with data from any telescope/instrument, but is built with the micro-shutter array (MSA) on the JWST/NIRSpec spectrograph and the JWST/NIRCam imager in mind.  As such, MOSViz has some features specific to NIRSpec and NIRCam data.
 
 The NIRSpec micro-shutter array (MSA) will produce ~100 spectra per pointing.  Many users will perform surveys with the MSA that will result in data sets of thousands to tens of thousands of spectra. Especially in the early days of JWST, careful inspection of all of the data will be critical to achieving scientific goals, and it is important to make this task efficient. Inspection involves looking at the locations of astronomical sources within shutters, the location of background apertures in the observed field, the quality of the 2D spectra, and the quality of the 1D extracted spectra. It also often involves simple interactive measurements of quantities such as wavelengths, velocities, line fluxes, widths.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of Specviz is **no longer being actively supported
+      or maintained**. The functionality of Specviz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 ************
 Installation
 ************

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 .. DANGER:: 
 
-      Please note that this version of Specviz is **no longer being actively supported
-      or maintained**. The functionality of Specviz is now available and being actively
+      Please note that this version of MOSViz is **no longer being actively supported
+      or maintained**. The functionality of MOSViz is now available and being actively
       developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 ************

--- a/docs/readingindata.rst
+++ b/docs/readingindata.rst
@@ -4,8 +4,8 @@
 
 .. DANGER:: 
 
-      Please note that this version of Specviz is **no longer being actively supported
-      or maintained**. The functionality of Specviz is now available and being actively
+      Please note that this version of MOSViz is **no longer being actively supported
+      or maintained**. The functionality of MOSViz is now available and being actively
       developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 ***************

--- a/docs/readingindata.rst
+++ b/docs/readingindata.rst
@@ -2,6 +2,12 @@
 
 .. _doc-sec-reading-data:
 
+.. DANGER:: 
+
+      Please note that this version of Specviz is **no longer being actively supported
+      or maintained**. The functionality of Specviz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 ***************
 Reading-in Data
 ***************


### PR DESCRIPTION
Adds a Deprecation Warning to the top of all doc pages directing users to Jdaviz for maintained mosviz development